### PR TITLE
Add rudimentary reconciliation fn

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: tibbar/of-operator
-  newTag: v0.0.2.1
+  newName: ghcr.io/open-feature/open-feature-operator
+  newTag: main


### PR DESCRIPTION
I implemented a very rudimentary reconciliation function. I'm sure this isn't production quality.

I tried to avoid the looping, but I wasn't able to get the ListOption field matchers to do the filtering I needed.

Anyway, if a FeatureFlagConfiguration CR is modified now, this updates the associated configMaps, though they take 10-20 seconds to appear updated to the container. Added lots of comments/thoughts inline.