### PR TITLE
Add provider nil check

### DIFF
--- a/webhooks/featureflagconfiguration_webhook.go
+++ b/webhooks/featureflagconfiguration_webhook.go
@@ -48,7 +48,7 @@ func (m *FeatureFlagConfigurationValidator) Handle(ctx context.Context, req admi
 		}
 	}
 
-	if config.Spec.Provider.Credentials.Name != "" {
+	if config.Spec.Provider != nil && config.Spec.Provider.Credentials.Name != "" {
 		// Check the provider and whether it has an existing secret
 		providerKeySecret := corev1.Secret{}
 		if err := m.Client.Get(ctx, client.ObjectKey{Name: config.Spec.Provider.Credentials.Name,


### PR DESCRIPTION
The `Credentials` member will be instantiated with zero-values, but we need to check the provider (since it's a pointer it can have a `nil` value).

Now both of these specs work without a nil deref error:

```
spec:
  provider:
    name: "flagD"
  featureFlagSpec: |
    {
      "booleanFlags": {
        "new-welcome-message": {
          "state": "enabled",
          "variants": {
            "enabled": true,
            "disabled": false
          },
          "defaultVariant": "disabled",
          "rules": []
        }
      }
    }
```

```
spec:
  featureFlagSpec: |
    {
      "booleanFlags": {
        "new-welcome-message": {
          "state": "enabled",
          "variants": {
            "enabled": true,
            "disabled": false
          },
          "defaultVariant": "disabled",
          "rules": []
        }
      }
    }
```

