### PR TITLE
Reduce app to 1 replica for simplicity and to demo no restart

### DIFF
--- a/config/samples/end-to-end.yaml
+++ b/config/samples/end-to-end.yaml
@@ -51,7 +51,7 @@ metadata:
   labels:
     app: open-feature-demo
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: open-feature-demo


### PR DESCRIPTION
Reduces the replicas in the demo app, which makes it easier to show change events in flagd sidecar logs, and also demos the fact that there's no restart when the CR / config map is updated... just a better demo overall.