### PR TITLE
feat: makefile deploy-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,14 @@ deploy: generate manifests kustomize ## Deploy controller to the K8s cluster spe
 undeploy: generate ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
+deploy-operator:
+	kubectl create ns 'open-feature-operator-system' --dry-run=client -o yaml | kubectl apply -f -
+	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.yaml
+	kubectl wait --for=condition=Available=True deploy --all -n 'cert-manager'
+	kubectl apply -f config/webhook/certificate.yaml
+	make deploy
+	kubectl wait --for=condition=Available=True deploy --all -n 'open-feature-operator-system'
+
 ##@ Build Dependencies
 
 ## Location to install dependencies to

--- a/README.md
+++ b/README.md
@@ -95,10 +95,7 @@ root@nginx:/# curl -X POST "localhost:8013/schema.v1.Service/ResolveString" -d '
 #### Create a local cluster with cert manager and our operator
 
 1.  Create a local cluster with MicroK8s or Kind (forward requests from your localhost:30000 to your cluster, see MicroK8s/Kind doc)
-1.  `kubectl create ns 'open-feature-operator-system'`
-1.  `kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/cert-manager.yaml`
-1.  `kubectl apply -f config/webhook/certificate.yaml`
-1.  `IMG=ghcr.io/open-feature/open-feature-operator:main make deploy`
+1.  `IMG=ghcr.io/open-feature/open-feature-operator:main make deploy-operator`
 
 #### Run the example
 


### PR DESCRIPTION
Signed-off-by: James-Milligan <james@omnant.co.uk>

- add the `make deploy-operator` command to manage the deployment of the operator / cert manager.


## This PR
The existing command sequence did not include any waits and as a result on a fresh cluster it was possible to provision the `end-to-end.yaml` without the webhook running, resulting in the flagd sidecar nto being injected into the pod. I created a makefile command called `make deploy-operator` which handles these awaits and creates the namespace.

- adds this new feature

### Related Issues

https://github.com/open-feature/open-feature-operator/issues/103

This issue is related, however it does not completely fulfill any of the criterea, as further work is requried.

### How to test

1.  Create a local cluster with MicroK8s or Kind (forward requests from your localhost:30000 to your cluster, see MicroK8s/Kind doc)
1.  `IMG=ghcr.io/open-feature/open-feature-operator:main make deploy-operator`

This will block until the operator is deployed and the deployments `Available` state is `true`
