### PR TITLE
chore: Updated workflow permissions for CLOMonitor status

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -63,7 +63,6 @@ jobs:
 
   docker-local:
     permissions:
-      contents: read  # for docker/build-push-action to read repo content
       security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,6 +8,10 @@ on:
 env:
   # Default minimum version of Go to support.
   DEFAULT_GO_VERSION: 1.18
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -58,6 +62,9 @@ jobs:
         uses: codecov/codecov-action@v3
 
   docker-local:
+    permissions:
+      contents: read  # for docker/build-push-action to read repo content
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -7,8 +7,14 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   main:
+    permissions:
+      pull-requests: read  # for amannn/action-semantic-pull-request to analyze PRs
+      statuses: write  # for amannn/action-semantic-pull-request to mark status of analyzed PR
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,8 +9,14 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
+    permissions:
+      contents: write  # for google-github-actions/release-please-action to create release commit
+      pull-requests: write  # for google-github-actions/release-please-action to create release PR
     runs-on: ubuntu-latest
 
     # Release-please creates a PR that tracks all changes
@@ -72,6 +78,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   release-assets:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
     needs: release-please
     runs-on: ubuntu-latest
     if: ${{ needs.release-please.outputs.release_created }}


### PR DESCRIPTION
Signed-off-by: Eddie Knight <knight@linux.com>

## This PR
Adds permissions to the github actions workflows based on recommendations by CLOMonitor and OpenSSF scorecard.

### Related Issues

Part of #139 

### Notes

Contributing this based on discussion with @justinabrahms as part of the CNCF Security Slam