### PR TITLE
chore: Sign the container in the repo

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -102,6 +102,21 @@ jobs:
 
         - uses: anchore/sbom-action@v0
 
+        - name: Install cosign
+          uses: sigstore/cosign-installer@main
+          with:
+            cosign-release: 'v1.13.0'
+
+        - name: Sign release image
+          run: |
+            cosign sign --key env://COSIGN_PRIVATE_KEY ghcr.io/open-feature/open-feature-operator:${{ needs.release-please.outputs.release_tag_name }}
+            # Displays the public key to share.
+            cosign public-key --key env://COSIGN_PRIVATE_KEY > ./cosign.pub
+          env:
+            COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
+            COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
+          if: ${{ env.DRY_RUN != 'true' }}
+  
         - name: Release
           uses: softprops/action-gh-release@v1
           with:


### PR DESCRIPTION
Sign the image using [cosign](https://docs.sigstore.dev/cosign/overview/) when making releases.