### PR TITLE
chore: remove namespace argument from e2e example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ root@nginx:/# curl -X POST "localhost:8013/schema.v1.Service/ResolveString" -d '
 
 #### Run the example
 
-1. Apply the end-to-end example: `kubectl -n open-feature-operator-system apply -f config/samples/end-to-end.yaml`
+1. Apply the end-to-end example: `kubectl apply -f config/samples/end-to-end.yaml`
 1. Visit `http://localhost:30000/`
 1. Update the value of the `defaultVariant` field in the custom resource instance in `config/samples/end-to-end.yaml` and re-apply to update the flag value!
 1. Visit `http://localhost:30000/` and see the change!


### PR DESCRIPTION
## This PR

Removes namespace argument from e2e example in readme

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #201 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

