### PR TITLE
chore: revert kustomization image name change

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ghcr.io/open-feature/open-feature-operator
-  newTag: main
+  newName: controller
+  newTag: latest


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

Reverts kustomization image name change.

### Related Issues

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

