### PR TITLE
test: resolve race condition in e2e tests

### DIFF
--- a/test/e2e/simple-flag-evaluation.sh
+++ b/test/e2e/simple-flag-evaluation.sh
@@ -1,28 +1,26 @@
 #!/bin/bash
 
 EXPECTED_RESPONSE="$1"
-
 # attempt up to 5 times
-ATTEMPT_COUNTER=0
 MAX_ATTEMPTS=5
-until RESPONSE=$(curl -s -X POST "localhost:30000/schema.v1.Service/ResolveBoolean" -d '{"flagKey":"simple-flag","context":{}}' -H "Content-Type: application/json"); do
-    if [ ${ATTEMPT_COUNTER} -eq ${MAX_ATTEMPTS} ];then
-      echo "Max attempts reached"
-      exit 1
+# retry every x seconds
+RETRY_INTERVAL=1
+
+for (( ATTEMPT_COUNTER=0; ATTEMPT_COUNTER<=${MAX_ATTEMPTS}; ATTEMPT_COUNTER++ ))
+do 
+
+    RESPONSE=$(curl -s -X POST "localhost:30000/schema.v1.Service/ResolveBoolean" -d '{"flagKey":"simple-flag","context":{}}' -H "Content-Type: application/json")
+    RESPONSE="${RESPONSE//[[:space:]]/}" # strip whitespace from response
+   
+    if [ "$RESPONSE" == "$EXPECTED_RESPONSE" ]
+    then
+      exit 0
     fi
 
-    printf '.'
-    ATTEMPT_COUNTER=$((ATTEMPT_COUNTER+1))
-    sleep 1
+    echo "Expected response: $EXPECTED_RESPONSE"
+    echo "Got response: $RESPONSE"
+    echo "Retrying in ${RETRY_INTERVAL} seconds"
+    sleep ${RETRY_INTERVAL}
 done
-
-RESPONSE="${RESPONSE//[[:space:]]/}" # strip whitespace from response
-
-if [ "$RESPONSE" == "$EXPECTED_RESPONSE" ]
-then
-  exit 0
-else
-  echo "Expected response: $EXPECTED_RESPONSE"
-  echo "Got response: $RESPONSE"
-  exit 1
-fi
+echo "Max attempts reached"
+exit 1


### PR DESCRIPTION
Signed-off-by: James Milligan <james@omnant.co.uk>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- check response within the reply loop, resolves a race condition found in the `002.crd-configuration-reconciliation` test

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

https://github.com/open-feature/open-feature-operator/issues/263

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

