### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
-* @AlexsJones @beeme1mr
+* @AlexsJones @beeme1mr @skyerus


### PR DESCRIPTION
I think that flagd and OFO are at the size and complexity that we need more CODEOWNERS. I think there's simply too many issues for a single person to keep up with.

I think 3 is a good number. It means that even if one CODEOWNER is away, there is one other person who can approve.

Relates to: https://github.com/open-feature/flagd/pull/228