### PR TITLE
chore: renovate regex manager to monitor FLAGD_VERSION in Makefile

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -72,7 +72,7 @@ kubectl describe pod busybox-curl-7bd5767999-spf7v
 ```
 ```yaml
   flagd:
-    Image:         ghcr.io/open-feature/flagd:vX.X.X
+    Image:         ghcr.io/open-feature/flagd:v0.3.0
     Port:          8014/TCP
     Host Port:     0/TCP
     Args:

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
       "datasourceTemplate": "github-releases"
     },
     {
-      "fileMatch": ["^README.md$"],
+      "fileMatch": ["^getting_started.md$"],
       "matchStrings": ["ghcr.io/open-feature/flagd:(?<currentValue>.*?)\\n"],
       "depNameTemplate": "open-feature/flagd",
       "datasourceTemplate": "github-releases"

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": ["FLAGD_VERSION=(?<currentValue>.*?)\\n"],
+      "depNameTemplate": "open-feature/flagd",
+      "datasourceTemplate": "github-releases"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -11,8 +11,8 @@
       "datasourceTemplate": "github-releases"
     },
     {
-      "fileMatch": ["^getting_started.md$"],
-      "matchStrings": ["ghcr.io/open-feature/flagd:(?<currentValue>.*?)\\n"],
+      "fileMatch": ["^docs/getting_started.md$"],
+      "matchStrings": ["ghcr\\.io\\/open-feature\\/flagd:(?<currentValue>.*?)\\n"],
       "depNameTemplate": "open-feature/flagd",
       "datasourceTemplate": "github-releases"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,12 @@
       "matchStrings": ["FLAGD_VERSION=(?<currentValue>.*?)\\n"],
       "depNameTemplate": "open-feature/flagd",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "fileMatch": ["^README.md$"],
+      "matchStrings": ["ghcr.io/open-feature/flagd:(?<currentValue>.*?)\\n"],
+      "depNameTemplate": "open-feature/flagd",
+      "datasourceTemplate": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
## This PR

Configures renovate to use a regex manager to monitor the FLAGD_VERSION in Makefile.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #291 

### Notes

Tested that this works in my forked repo: https://github.com/skyerus/open-feature-operator/pull/63/files

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

