### PR TITLE
fix: mount dirs not files

### DIFF
--- a/apis/core/v1alpha1/featureflagconfiguration_types.go
+++ b/apis/core/v1alpha1/featureflagconfiguration_types.go
@@ -133,7 +133,7 @@ func GenerateFfConfigMap(name string, namespace string, references []metav1.Owne
 	}
 }
 
-// unique string based used to create unique volume mount and file name
+// unique string used to create unique volume mount and file name
 func FeatureFlagConfigurationId(namespace, name string) string {
 	return fmt.Sprintf("%s_%s", namespace, name)
 }

--- a/apis/core/v1alpha1/featureflagconfiguration_types.go
+++ b/apis/core/v1alpha1/featureflagconfiguration_types.go
@@ -128,11 +128,17 @@ func GenerateFfConfigMap(name string, namespace string, references []metav1.Owne
 			OwnerReferences: references,
 		},
 		Data: map[string]string{
-			FeatureFlagConfigurationConfigMapDataKeyName(namespace, name): spec.FeatureFlagSpec,
+			FeatureFlagConfigurationConfigMapKey(namespace, name): spec.FeatureFlagSpec,
 		},
 	}
 }
 
-func FeatureFlagConfigurationConfigMapDataKeyName(namespace, name string) string {
-	return fmt.Sprintf("%s_%s.json", namespace, name)
+// unique string based used to create unique volume mount and file name
+func FeatureFlagConfigurationId(namespace, name string) string {
+	return fmt.Sprintf("%s_%s", namespace, name)
+}
+
+// unique key (and filename) for configMap data
+func FeatureFlagConfigurationConfigMapKey(namespace, name string) string {
+	return fmt.Sprintf("%s.json", FeatureFlagConfigurationId(namespace, name))
 }

--- a/apis/core/v1alpha1/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha1/flagsourceconfiguration_types.go
@@ -72,7 +72,7 @@ type FlagSourceConfigurationSpec struct {
 	// +optional
 	SocketPath string `json:"socketPath"`
 
-	//SyncProviderArgs are string arguments passed to all sync providers, defined as key values separated by =
+	// SyncProviderArgs are string arguments passed to all sync providers, defined as key values separated by =
 	// +optional
 	SyncProviderArgs []string `json:"syncProviderArgs"`
 

--- a/apis/core/v1alpha2/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha2/flagsourceconfiguration_types.go
@@ -40,7 +40,7 @@ type FlagSourceConfigurationSpec struct {
 	// +optional
 	SocketPath string `json:"socketPath"`
 
-	//SyncProviderArgs are string arguments passed to all sync providers, defined as key values separated by =
+	// SyncProviderArgs are string arguments passed to all sync providers, defined as key values separated by =
 	// +optional
 	SyncProviderArgs []string `json:"syncProviderArgs"`
 

--- a/controllers/featureflagconfiguration_controller.go
+++ b/controllers/featureflagconfiguration_controller.go
@@ -150,7 +150,7 @@ func (r *FeatureFlagConfigurationReconciler) Reconcile(ctx context.Context, req 
 		// Update ConfigMap Spec
 		r.Log.Info("Updating ConfigMap Spec " + cm.Name)
 		cm.Data = map[string]string{
-			corev1alpha1.FeatureFlagConfigurationConfigMapDataKeyName(cm.Namespace, cm.Name): ffconf.Spec.FeatureFlagSpec,
+			corev1alpha1.FeatureFlagConfigurationConfigMapKey(cm.Namespace, cm.Name): ffconf.Spec.FeatureFlagSpec,
 		}
 		err := r.Client.Update(ctx, &cm)
 		if err != nil {

--- a/webhooks/featureflagconfiguration_webhook_test.go
+++ b/webhooks/featureflagconfiguration_webhook_test.go
@@ -13,8 +13,7 @@ const (
 	featureFlagConfigurationNamespace = "test-validate-featureflagconfiguration"
 )
 
-var (
-	featureFlagSpec = `
+var featureFlagSpec = `
 	{
       "flags": {
         "new-welcome-message": {
@@ -28,7 +27,6 @@ var (
       }
     }
 	`
-)
 
 func setupValidateFeatureFlagConfigurationResources() {
 	ns := &corev1.Namespace{}

--- a/webhooks/pod_webhook.go
+++ b/webhooks/pod_webhook.go
@@ -247,8 +247,10 @@ func podOwnerIsOwner(pod *corev1.Pod, cm corev1.ConfigMap) bool {
 }
 
 func (m *PodMutator) enableClusterRoleBinding(ctx context.Context, pod *corev1.Pod) error {
-	var serviceAccount = client.ObjectKey{Name: pod.Spec.ServiceAccountName,
-		Namespace: pod.Namespace}
+	serviceAccount := client.ObjectKey{
+		Name:      pod.Spec.ServiceAccountName,
+		Namespace: pod.Namespace,
+	}
 	if pod.Spec.ServiceAccountName == "" {
 		serviceAccount.Name = "default"
 	}
@@ -266,7 +268,7 @@ func (m *PodMutator) enableClusterRoleBinding(ctx context.Context, pod *corev1.P
 		m.Log.V(1).Info(fmt.Sprintf("ClusterRoleBinding not found: %s", clusterRoleBindingName))
 		return err
 	}
-	var found = false
+	found := false
 	for _, subject := range crb.Subjects {
 		if subject.Kind == "ServiceAccount" && subject.Name == serviceAccount.Name && subject.Namespace == serviceAccount.Namespace {
 			m.Log.V(1).Info(fmt.Sprintf("ClusterRoleBinding already exists for service account: %s/%s", serviceAccount.Namespace, serviceAccount.Name))

--- a/webhooks/pod_webhook_test.go
+++ b/webhooks/pod_webhook_test.go
@@ -167,7 +167,6 @@ func podMutationWebhookCleanup() {
 }
 
 var _ = Describe("pod mutation webhook", func() {
-
 	It("should backfill role binding subjects when annotated pods already exist in the cluster", func() {
 		// this integration test confirms the proper execution of the  podMutator.BackfillPermissions method
 		// this method is responsible for backfilling the subjects of the open-feature-operator-flagd-kubernetes-sync

--- a/webhooks/pod_webhook_test.go
+++ b/webhooks/pod_webhook_test.go
@@ -455,7 +455,7 @@ var _ = Describe("pod mutation webhook", func() {
 		Expect(pod.Spec.Containers[1].Args).To(Equal([]string{
 			"start",
 			"--uri",
-			"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration.json",
+			"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration/test-mutate-pod_test-feature-flag-configuration.json",
 			"--sync-provider-args",
 			"key=value",
 			"--sync-provider-args",

--- a/webhooks/suite_test.go
+++ b/webhooks/suite_test.go
@@ -32,10 +32,12 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var testCtx, testCancel = context.WithCancel(context.Background())
+var (
+	cfg                 *rest.Config
+	k8sClient           client.Client
+	testEnv             *envtest.Environment
+	testCtx, testCancel = context.WithCancel(context.Background())
+)
 
 const (
 	podMutatingWebhookPath                        = "/mutate-v1-pod"


### PR DESCRIPTION
We need to mount dirs, not files, so our previous solution to handle multiple configmaps didn't work (events weren't being seen in flagd).

This change mounts each ff/configmap in it's own unique dir, preserving all events and allowing multiples.