### PR TITLE
fix: set defaultTag to INPUT_FLAGD_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: docker-build
-docker-build:  ## Build docker image with the manager.
+docker-build: update-flagd  ## Build docker image with the manager.
 	docker buildx build --platform="linux/amd64,linux/arm64" -t ${IMG} . --push
 
 .PHONY: docker-push

--- a/apis/core/v1alpha1/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha1/flagsourceconfiguration_types.go
@@ -29,28 +29,28 @@ import (
 type SyncProviderType string
 
 const (
-	SidecarEnvVarPrefix              string           = "SIDECAR_ENV_VAR_PREFIX"
-	SidecarMetricPortEnvVar          string           = "METRICS_PORT"
-	SidecarPortEnvVar                string           = "PORT"
-	SidecarSocketPathEnvVar          string           = "SOCKET_PATH"
-	SidecarEvaluatorEnvVar           string           = "EVALUATOR"
-	SidecarImageEnvVar               string           = "IMAGE"
-	SidecarVersionEnvVar             string           = "TAG"
-	SidecarProviderArgsEnvVar        string           = "PROVIDER_ARGS"
-	SidecarDefaultSyncProviderEnvVar string           = "SYNC_PROVIDER"
-	defaultSidecarEnvVarPrefix       string           = "FLAGD"
-	InputConfigurationEnvVarPrefix   string           = "SIDECAR"
-	defaultMetricPort                int32            = 8014
-	defaultPort                      int32            = 8013
-	defaultSocketPath                string           = ""
-	defaultEvaluator                 string           = "json"
-	defaultImage                     string           = "ghcr.io/open-feature/flagd"
-        // `INPUT_FLAGD_VERSION` is replaced in the `update-flagd` Makefile target
-	defaultTag                       string           = "INPUT_FLAGD_VERSION"
-	SyncProviderKubernetes           SyncProviderType = "kubernetes"
-	SyncProviderFilepath             SyncProviderType = "filepath"
-	SyncProviderHttp                 SyncProviderType = "http"
-	defaultSyncProvider                               = SyncProviderKubernetes
+	SidecarEnvVarPrefix              string = "SIDECAR_ENV_VAR_PREFIX"
+	SidecarMetricPortEnvVar          string = "METRICS_PORT"
+	SidecarPortEnvVar                string = "PORT"
+	SidecarSocketPathEnvVar          string = "SOCKET_PATH"
+	SidecarEvaluatorEnvVar           string = "EVALUATOR"
+	SidecarImageEnvVar               string = "IMAGE"
+	SidecarVersionEnvVar             string = "TAG"
+	SidecarProviderArgsEnvVar        string = "PROVIDER_ARGS"
+	SidecarDefaultSyncProviderEnvVar string = "SYNC_PROVIDER"
+	defaultSidecarEnvVarPrefix       string = "FLAGD"
+	InputConfigurationEnvVarPrefix   string = "SIDECAR"
+	defaultMetricPort                int32  = 8014
+	defaultPort                      int32  = 8013
+	defaultSocketPath                string = ""
+	defaultEvaluator                 string = "json"
+	defaultImage                     string = "ghcr.io/open-feature/flagd"
+	// `INPUT_FLAGD_VERSION` is replaced in the `update-flagd` Makefile target
+	defaultTag             string           = "INPUT_FLAGD_VERSION"
+	SyncProviderKubernetes SyncProviderType = "kubernetes"
+	SyncProviderFilepath   SyncProviderType = "filepath"
+	SyncProviderHttp       SyncProviderType = "http"
+	defaultSyncProvider                     = SyncProviderKubernetes
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/apis/core/v1alpha1/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha1/flagsourceconfiguration_types.go
@@ -45,6 +45,7 @@ const (
 	defaultSocketPath                string           = ""
 	defaultEvaluator                 string           = "json"
 	defaultImage                     string           = "ghcr.io/open-feature/flagd"
+        // `INPUT_FLAGD_VERSION` is replaced in the `update-flagd` Makefile target
 	defaultTag                       string           = "INPUT_FLAGD_VERSION"
 	SyncProviderKubernetes           SyncProviderType = "kubernetes"
 	SyncProviderFilepath             SyncProviderType = "filepath"


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

Sets defaultTag to `INPUT_FLAGD_VERSION`, this fixes `make update-flagd`.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->


### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

