### PR TITLE
chore: test filepath sync config change is reconciliated

### DIFF
--- a/test/e2e/flag-evaluation.sh
+++ b/test/e2e/flag-evaluation.sh
@@ -2,12 +2,22 @@
 
 FLAG_KEY="$1"
 EXPECTED_RESPONSE="$2"
+
 # attempt up to 5 times
 MAX_ATTEMPTS=5
 # retry every x seconds
 RETRY_INTERVAL=1
+if [[ "$3" =~ ^[0-9]+$ ]]
+  then
+    MAX_ATTEMPTS=$3
+fi
+if [[ "$4" =~ ^[0-9]+$ ]]
+  then
+    RETRY_INTERVAL=$4
+fi
 
-for (( ATTEMPT_COUNTER=0; ATTEMPT_COUNTER<=${MAX_ATTEMPTS}; ATTEMPT_COUNTER++ ))
+
+for (( ATTEMPT_COUNTER=0; ATTEMPT_COUNTER<${MAX_ATTEMPTS}; ATTEMPT_COUNTER++ ))
 do 
 
     RESPONSE=$(curl -s -X POST "localhost:30000/schema.v1.Service/ResolveBoolean" -d "{\"flagKey\":\"$FLAG_KEY\",\"context\":{}}" -H "Content-Type: application/json")
@@ -21,7 +31,7 @@ do
     echo "Expected response for flag $FLAG_KEY: $EXPECTED_RESPONSE"
     echo "Got response for flag $FLAG_KEY: $RESPONSE"
     echo "Retrying in ${RETRY_INTERVAL} seconds"
-    sleep ${RETRY_INTERVAL}
+    sleep "${RETRY_INTERVAL}"
 done
 echo "Max attempts reached"
 exit 1

--- a/test/e2e/tests/001.flagd-response.sh
+++ b/test/e2e/tests/001.flagd-response.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
-./"$(dirname "${BASH_SOURCE[0]}")"/../flag-evaluation.sh simple-flag '{"value":true,"reason":"STATIC","variant":"on"}'
-./"$(dirname "${BASH_SOURCE[0]}")"/../flag-evaluation.sh simple-flag-filepath '{"value":true,"reason":"STATIC","variant":"on"}'
-./"$(dirname "${BASH_SOURCE[0]}")"/../flag-evaluation.sh simple-flag-filepath2 '{"value":true,"reason":"STATIC","variant":"on"}'
+FAILURE=0
+
+flagKeys=('simple-flag' 'simple-flag-filepath' 'simple-flag-filepath2')
+expectedFlagResponses=('{"value":true,"reason":"STATIC","variant":"on"}' '{"value":true,"reason":"STATIC","variant":"on"}' '{"value":true,"reason":"STATIC","variant":"on"}')
+
+for i in "${!flagKeys[@]}"; do
+  ./"$(dirname "${BASH_SOURCE[0]}")"/../flag-evaluation.sh "${flagKeys[$i]}" "${expectedFlagResponses[$i]}"
+  EXIT_CODE=$?
+  if [ $EXIT_CODE -ne 0 ];
+    then
+      FAILURE=1
+  fi
+done
+
+if [ $FAILURE -eq 1 ];
+then
+  exit 1
+fi

--- a/test/e2e/tests/003.configmap-configuration-reconciliation.sh
+++ b/test/e2e/tests/003.configmap-configuration-reconciliation.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+cat <<EOF | kubectl -n open-feature-operator-system apply -f -
+apiVersion: core.openfeature.dev/v1alpha2
+kind: FeatureFlagConfiguration
+metadata:
+  name: end-to-end-test-filepath
+spec:
+  syncProvider:
+    name: filepath
+  featureFlagSpec:
+    flags:
+      simple-flag-filepath:
+        state: ENABLED
+        variants:
+          "on": true
+          "off": false
+        defaultVariant: "off"
+EOF
+
+# filepath sync provider takes up to 2 minutes to synchronize, retry every 10 seconds up to 12 times
+./"$(dirname "${BASH_SOURCE[0]}")"/../flag-evaluation.sh simple-flag-filepath '{"reason":"STATIC","variant":"off"}' 12 10
+EXIT_CODE=$?
+
+kubectl -n open-feature-operator-system apply -f ./test/e2e/e2e.yml > /dev/null # reset state quietly
+
+exit $EXIT_CODE


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

Introduces e2e test coverage of filepath sync provider config update reconciliation.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #333 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

