### PR TITLE
feat: add log format configuration options through helm chart

### DIFF
--- a/apis/core/v1alpha1/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha1/flagsourceconfiguration_types.go
@@ -97,7 +97,6 @@ type FlagSourceConfigurationSpec struct {
 
 	// LogFormat allows for the sidecar log format to be overridden, defaults to 'json'
 	// +optional
-	// +kubebuilder:default:=json
 	LogFormat string `json:"logFormat"`
 }
 

--- a/apis/core/v1alpha1/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha1/flagsourceconfiguration_types.go
@@ -46,8 +46,8 @@ const (
 	defaultSocketPath                string = ""
 	defaultEvaluator                 string = "json"
 	defaultImage                     string = "ghcr.io/open-feature/flagd"
-	// `INPUT_FLAGD_VERSION` is replaced in the `update-flagd` Makefile target
-	defaultTag             string           = "INPUT_FLAGD_VERSION"
+	// `v0.3.4` is replaced in the `update-flagd` Makefile target
+	defaultTag             string           = "v0.3.4"
 	defaultLogFormat       string           = "json"
 	SyncProviderKubernetes SyncProviderType = "kubernetes"
 	SyncProviderFilepath   SyncProviderType = "filepath"
@@ -95,10 +95,10 @@ type FlagSourceConfigurationSpec struct {
 	// +optional
 	DefaultSyncProvider SyncProviderType `json:"defaultSyncProvider"`
 
-	// DefaultLogFormat allows for the sidecar log format to be overridden, defaults to 'json'
+	// LogFormat allows for the sidecar log format to be overridden, defaults to 'json'
 	// +optional
 	// +kubebuilder:default:=json
-	DefaultLogFormat string `json:"logFormat"`
+	LogFormat string `json:"logFormat"`
 }
 
 func NewFlagSourceConfigurationSpec() (*FlagSourceConfigurationSpec, error) {
@@ -184,6 +184,9 @@ func (fc *FlagSourceConfigurationSpec) Merge(new *FlagSourceConfigurationSpec) {
 	if new.DefaultSyncProvider != "" {
 		fc.DefaultSyncProvider = new.DefaultSyncProvider
 	}
+	if new.LogFormat != "" {
+		fc.LogFormat = new.LogFormat
+	}
 }
 
 func (fc *FlagSourceConfigurationSpec) ToEnvVars() []corev1.EnvVar {
@@ -222,10 +225,10 @@ func (fc *FlagSourceConfigurationSpec) ToEnvVars() []corev1.EnvVar {
 		})
 	}
 
-	if fc.DefaultLogFormat != defaultLogFormat {
+	if fc.LogFormat != defaultLogFormat {
 		envs = append(envs, corev1.EnvVar{
 			Name:  fmt.Sprintf("%s_%s", prefix, SidecarLogFormatEnvVar),
-			Value: fc.DefaultLogFormat,
+			Value: fc.LogFormat,
 		})
 	}
 	return envs

--- a/apis/core/v1alpha1/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha1/flagsourceconfiguration_types.go
@@ -38,6 +38,7 @@ const (
 	SidecarVersionEnvVar             string = "TAG"
 	SidecarProviderArgsEnvVar        string = "PROVIDER_ARGS"
 	SidecarDefaultSyncProviderEnvVar string = "SYNC_PROVIDER"
+	SidecarLogFormatEnvVar           string = "LOG_FORMAT"
 	defaultSidecarEnvVarPrefix       string = "FLAGD"
 	InputConfigurationEnvVarPrefix   string = "SIDECAR"
 	defaultMetricPort                int32  = 8014
@@ -47,6 +48,7 @@ const (
 	defaultImage                     string = "ghcr.io/open-feature/flagd"
 	// `INPUT_FLAGD_VERSION` is replaced in the `update-flagd` Makefile target
 	defaultTag             string           = "INPUT_FLAGD_VERSION"
+	defaultLogFormat       string           = "json"
 	SyncProviderKubernetes SyncProviderType = "kubernetes"
 	SyncProviderFilepath   SyncProviderType = "filepath"
 	SyncProviderHttp       SyncProviderType = "http"
@@ -92,6 +94,11 @@ type FlagSourceConfigurationSpec struct {
 	// DefaultSyncProvider defines the default sync provider
 	// +optional
 	DefaultSyncProvider SyncProviderType `json:"defaultSyncProvider"`
+
+	// DefaultLogFormat allows for the sidecar log format to be overridden, defaults to 'json'
+	// +optional
+	// +kubebuilder:default:=json
+	DefaultLogFormat string `json:"logFormat"`
 }
 
 func NewFlagSourceConfigurationSpec() (*FlagSourceConfigurationSpec, error) {
@@ -212,6 +219,13 @@ func (fc *FlagSourceConfigurationSpec) ToEnvVars() []corev1.EnvVar {
 		envs = append(envs, corev1.EnvVar{
 			Name:  fmt.Sprintf("%s_%s", prefix, SidecarSocketPathEnvVar),
 			Value: fc.SocketPath,
+		})
+	}
+
+	if fc.DefaultLogFormat != defaultLogFormat {
+		envs = append(envs, corev1.EnvVar{
+			Name:  fmt.Sprintf("%s_%s", prefix, SidecarLogFormatEnvVar),
+			Value: fc.DefaultLogFormat,
 		})
 	}
 	return envs

--- a/apis/core/v1alpha1/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha1/flagsourceconfiguration_types.go
@@ -111,6 +111,7 @@ func NewFlagSourceConfigurationSpec() (*FlagSourceConfigurationSpec, error) {
 		Image:               defaultImage,
 		Tag:                 defaultTag,
 		DefaultSyncProvider: SyncProviderKubernetes,
+		LogFormat:           defaultLogFormat,
 	}
 
 	if metricsPort := os.Getenv(fmt.Sprintf("%s_%s", InputConfigurationEnvVarPrefix, SidecarMetricPortEnvVar)); metricsPort != "" {
@@ -151,6 +152,10 @@ func NewFlagSourceConfigurationSpec() (*FlagSourceConfigurationSpec, error) {
 
 	if syncProvider := os.Getenv(fmt.Sprintf("%s_%s", InputConfigurationEnvVarPrefix, SidecarDefaultSyncProviderEnvVar)); syncProvider != "" {
 		fsc.DefaultSyncProvider = SyncProviderType(syncProvider)
+	}
+
+	if logFormat := os.Getenv(fmt.Sprintf("%s_%s", InputConfigurationEnvVarPrefix, SidecarLogFormatEnvVar)); logFormat != "" {
+		fsc.LogFormat = logFormat
 	}
 
 	return fsc, nil

--- a/apis/core/v1alpha1/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha1/flagsourceconfiguration_types.go
@@ -46,8 +46,8 @@ const (
 	defaultSocketPath                string = ""
 	defaultEvaluator                 string = "json"
 	defaultImage                     string = "ghcr.io/open-feature/flagd"
-	// `v0.3.4` is replaced in the `update-flagd` Makefile target
-	defaultTag             string           = "v0.3.4"
+	// `INPUT_FLAGD_VERSION` is replaced in the `update-flagd` Makefile target
+	defaultTag             string           = "INPUT_FLAGD_VERSION"
 	defaultLogFormat       string           = "json"
 	SyncProviderKubernetes SyncProviderType = "kubernetes"
 	SyncProviderFilepath   SyncProviderType = "filepath"

--- a/apis/core/v1alpha2/flagsourceconfiguration_conversion.go
+++ b/apis/core/v1alpha2/flagsourceconfiguration_conversion.go
@@ -40,6 +40,7 @@ func (src *FlagSourceConfiguration) ConvertTo(dstRaw conversion.Hub) error {
 		Evaluator:           src.Spec.Evaluator,
 		Image:               src.Spec.Image,
 		Tag:                 src.Spec.Tag,
+		LogFormat:           src.Spec.LogFormat,
 		DefaultSyncProvider: v1alpha1.SyncProviderType(src.Spec.DefaultSyncProvider),
 	}
 	return nil
@@ -57,6 +58,7 @@ func (dst *FlagSourceConfiguration) ConvertFrom(srcRaw conversion.Hub) error {
 		Evaluator:           src.Spec.Evaluator,
 		Image:               src.Spec.Image,
 		Tag:                 src.Spec.Tag,
+		LogFormat:           src.Spec.LogFormat,
 		DefaultSyncProvider: string(src.Spec.DefaultSyncProvider),
 	}
 	return nil

--- a/apis/core/v1alpha2/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha2/flagsourceconfiguration_types.go
@@ -62,7 +62,6 @@ type FlagSourceConfigurationSpec struct {
 
 	// LogFormat allows for the sidecar log format to be overridden, defaults to 'json'
 	// +optional
-	// +kubebuilder:default:=json
 	LogFormat string `json:"logFormat"`
 }
 

--- a/apis/core/v1alpha2/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha2/flagsourceconfiguration_types.go
@@ -59,6 +59,11 @@ type FlagSourceConfigurationSpec struct {
 	// DefaultSyncProvider defines the default sync provider
 	// +optional
 	DefaultSyncProvider string `json:"defaultSyncProvider"`
+
+	// LogFormat allows for the sidecar log format to be overridden, defaults to 'json'
+	// +optional
+	// +kubebuilder:default:=json
+	LogFormat string `json:"logFormat"`
 }
 
 // FlagSourceConfigurationStatus defines the observed state of FlagSourceConfiguration

--- a/chart/open-feature-operator/README.md
+++ b/chart/open-feature-operator/README.md
@@ -43,16 +43,17 @@ The command removes all the Kubernetes components associated with the chart and 
 <a name="configuration"></a>
 
 ### Sidecar configuration
-| Value       | Default     | Explanation |
-| ----------- | ----------- | ----------- |
-| `sidecarConfiguration.envVarPrefix`      | `FLAGD`  | Sets the prefix for all environment variables set in the injected sidecar. |
-| `sidecarConfiguration.port`      | 8013  | Sets the value of the `XXX_PORT` environment variable for the injected sidecar container.|
-| `sidecarConfiguration.metricsPort`      | 8014  | Sets the value of the `XXX_METRICS_PORT` environment variable for the injected sidecar container.|
-| `sidecarConfiguration.socketPath`      | `""`  | Sets the value of the `XXX_SOCKET_PATH` environment variable for the injected sidecar container.|
-| `sidecarConfiguration.image.repository`      | `ghcr.io/open-feature/flagd`  | Sets the image for the injected sidecar container. |
-| `sidecarConfiguration.image.tag`      | current flagd version: `v0.3.4`  | Sets the version tag for the injected sidecar container. |
+| Value       | Default     | Explanation                                                                                                                                                                                                                                               |
+| ----------- | ----------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `sidecarConfiguration.envVarPrefix`      | `FLAGD`  | Sets the prefix for all environment variables set in the injected sidecar.                                                                                                                                                                                |
+| `sidecarConfiguration.port`      | 8013  | Sets the value of the `XXX_PORT` environment variable for the injected sidecar container.                                                                                                                                                                 |
+| `sidecarConfiguration.metricsPort`      | 8014  | Sets the value of the `XXX_METRICS_PORT` environment variable for the injected sidecar container.                                                                                                                                                         |
+| `sidecarConfiguration.socketPath`      | `""`  | Sets the value of the `XXX_SOCKET_PATH` environment variable for the injected sidecar container.                                                                                                                                                          |
+| `sidecarConfiguration.image.repository`      | `ghcr.io/open-feature/flagd`  | Sets the image for the injected sidecar container.                                                                                                                                                                                                        |
+| `sidecarConfiguration.image.tag`      | current flagd version: `v0.3.4`  | Sets the version tag for the injected sidecar container.                                                                                                                                                                                                  |
 | `sidecarConfiguration.providerArgs`      | `""`  | Used to append arguments to the sidecar startup command. This value is a comma separated string of key values separated by '=', e.g. `key=value,key2=value2` results in the appending of `--sync-provider-args key=value --sync-provider-args key2=value2` |
-| `sidecarConfiguration.defaultSyncProvider`      | `kubernetes`  | Sets the value of the `XXX_SYNC_PROVIDER` environment variable for the injected sidecar container. There are 3 valid sync providers: `kubernetes`, `filepath` and `http` |
+| `sidecarConfiguration.defaultSyncProvider`      | `kubernetes`  | Sets the value of the `XXX_SYNC_PROVIDER` environment variable for the injected sidecar container. There are 3 valid sync providers: `kubernetes`, `filepath` and `http`                                                                                  |
+| `sidecarConfiguration.logFormat` | `json` | Sets the log format used by the flagD sidecar. `json` and `console` are possible                                                                                                                                                                          |
 
 ### Operator resource configuration
 

--- a/chart/open-feature-operator/README.md
+++ b/chart/open-feature-operator/README.md
@@ -53,7 +53,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `sidecarConfiguration.image.tag`      | current flagd version: `v0.3.4`  | Sets the version tag for the injected sidecar container.                                                                                                                                                                                                  |
 | `sidecarConfiguration.providerArgs`      | `""`  | Used to append arguments to the sidecar startup command. This value is a comma separated string of key values separated by '=', e.g. `key=value,key2=value2` results in the appending of `--sync-provider-args key=value --sync-provider-args key2=value2` |
 | `sidecarConfiguration.defaultSyncProvider`      | `kubernetes`  | Sets the value of the `XXX_SYNC_PROVIDER` environment variable for the injected sidecar container. There are 3 valid sync providers: `kubernetes`, `filepath` and `http`                                                                                  |
-| `sidecarConfiguration.logFormat` | `json` | Sets the log format used by the flagD sidecar. `json` and `console` are possible                                                                                                                                                                          |
+| `sidecarConfiguration.logFormat` | `json` | Sets the value of the `XXX_LOG_FORMAT` environment variable for the injected sidecar container.                                                                                                                                                                          |
 
 ### Operator resource configuration
 

--- a/chart/open-feature-operator/templates/rendered.yaml
+++ b/chart/open-feature-operator/templates/rendered.yaml
@@ -617,6 +617,11 @@ spec:
                 description: Image allows for the sidecar image to be overridden,
                   defaults to 'ghcr.io/open-feature/flagd'
                 type: string
+              logFormat:
+                default: json
+                description: LogFormat allows for the sidecar log format to be overridden,
+                  defaults to 'json'
+                type: string
               metricsPort:
                 description: MetricsPort defines the port to serve metrics on, defaults
                   to 8014
@@ -680,6 +685,11 @@ spec:
               image:
                 description: Image allows for the sidecar image to be overridden,
                   defaults to 'ghcr.io/open-feature/flagd'
+                type: string
+              logFormat:
+                default: json
+                description: LogFormat allows for the sidecar log format to be overridden,
+                  defaults to 'json'
                 type: string
               metricsPort:
                 description: MetricsPort defines the port to serve metrics on, defaults
@@ -1043,6 +1053,8 @@ spec:
           value: '{{ .Values.sidecarConfiguration.envVarPrefix }}'
         - name: SIDECAR_SYNC_PROVIDER
           value: '{{ .Values.sidecarConfiguration.defaultSyncProvider }}'
+        - name: SIDECAR_LOG_FORMAT
+          value: '{{ .Values.sidecarConfiguration.logFormat }}'
         image: '{{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
           }}'
         imagePullPolicy: IfNotPresent

--- a/chart/open-feature-operator/values.yaml
+++ b/chart/open-feature-operator/values.yaml
@@ -12,6 +12,7 @@ sidecarConfiguration:
   providerArgs: ""
   envVarPrefix: "FLAGD"
   defaultSyncProvider: kubernetes
+  logFormat: "json"
 
 controllerManager:
   kubeRbacProxy:

--- a/config/crd/bases/core.openfeature.dev_flagsourceconfigurations.yaml
+++ b/config/crd/bases/core.openfeature.dev_flagsourceconfigurations.yaml
@@ -50,7 +50,6 @@ spec:
                   defaults to 'ghcr.io/open-feature/flagd'
                 type: string
               logFormat:
-                default: json
                 description: LogFormat allows for the sidecar log format to be overridden,
                   defaults to 'json'
                 type: string
@@ -119,7 +118,6 @@ spec:
                   defaults to 'ghcr.io/open-feature/flagd'
                 type: string
               logFormat:
-                default: json
                 description: LogFormat allows for the sidecar log format to be overridden,
                   defaults to 'json'
                 type: string

--- a/config/crd/bases/core.openfeature.dev_flagsourceconfigurations.yaml
+++ b/config/crd/bases/core.openfeature.dev_flagsourceconfigurations.yaml
@@ -49,6 +49,11 @@ spec:
                 description: Image allows for the sidecar image to be overridden,
                   defaults to 'ghcr.io/open-feature/flagd'
                 type: string
+              logFormat:
+                default: json
+                description: DefaultLogFormat allows for the sidecar log format to
+                  be overridden, defaults to 'json'
+                type: string
               metricsPort:
                 description: MetricsPort defines the port to serve metrics on, defaults
                   to 8014

--- a/config/crd/bases/core.openfeature.dev_flagsourceconfigurations.yaml
+++ b/config/crd/bases/core.openfeature.dev_flagsourceconfigurations.yaml
@@ -51,8 +51,8 @@ spec:
                 type: string
               logFormat:
                 default: json
-                description: DefaultLogFormat allows for the sidecar log format to
-                  be overridden, defaults to 'json'
+                description: LogFormat allows for the sidecar log format to be overridden,
+                  defaults to 'json'
                 type: string
               metricsPort:
                 description: MetricsPort defines the port to serve metrics on, defaults
@@ -117,6 +117,11 @@ spec:
               image:
                 description: Image allows for the sidecar image to be overridden,
                   defaults to 'ghcr.io/open-feature/flagd'
+                type: string
+              logFormat:
+                default: json
+                description: LogFormat allows for the sidecar log format to be overridden,
+                  defaults to 'json'
                 type: string
               metricsPort:
                 description: MetricsPort defines the port to serve metrics on, defaults

--- a/config/overlays/helm/manager.yaml
+++ b/config/overlays/helm/manager.yaml
@@ -34,6 +34,8 @@ spec:
             value: "{{ .Values.sidecarConfiguration.envVarPrefix }}"
           - name: SIDECAR_SYNC_PROVIDER
             value: "{{ .Values.sidecarConfiguration.defaultSyncProvider }}"
+          - name: SIDECAR_LOG_FORMAT
+            value: "{{ .Values.sidecarConfiguration.logFormat }}"
         - name: kube-rbac-proxy
           image: "{{ .Values.controllerManager.kubeRbacProxy.image.repository }}:{{ .Values.controllerManager.kubeRbacProxy.image.tag }}"
           resources:

--- a/docs/feature_flag_configuration.md
+++ b/docs/feature_flag_configuration.md
@@ -1,6 +1,6 @@
 # Feature Flag Configuration
 
-The `FeatureFlagConfiguration` version `v1alpha2` CRD defines the a CR with the following example structure:
+The `FeatureFlagConfiguration` version `v1alpha2` CRD defines a CR with the following example structure:
 
 ```yaml
 apiVersion: core.openfeature.dev/v1alpha2

--- a/webhooks/pod_webhook_test.go
+++ b/webhooks/pod_webhook_test.go
@@ -101,6 +101,7 @@ func setupMutatePodResources() {
 	fsConfig.Spec.SyncProviderArgs = []string{
 		"key3=val3",
 	}
+	fsConfig.Spec.LogFormat = "console"
 	err = k8sClient.Create(testCtx, fsConfig)
 	Expect(err).ShouldNot(HaveOccurred())
 }
@@ -387,6 +388,7 @@ var _ = Describe("pod mutation webhook", func() {
 			{Name: "FLAGD_PORT", Value: "8080"},
 			{Name: "FLAGD_EVALUATOR", Value: "yaml"},
 			{Name: "FLAGD_SOCKET_PATH", Value: "/tmp/flag-source.sock"},
+			{Name: "FLAGD_LOG_FORMAT", Value: "console"},
 		}))
 
 		podMutationWebhookCleanup()
@@ -402,6 +404,7 @@ var _ = Describe("pod mutation webhook", func() {
 		os.Setenv(fmt.Sprintf("%s_%s", corev1alpha1.InputConfigurationEnvVarPrefix, corev1alpha1.SidecarVersionEnvVar), "version")
 		os.Setenv(fmt.Sprintf("%s_%s", corev1alpha1.InputConfigurationEnvVarPrefix, corev1alpha1.SidecarDefaultSyncProviderEnvVar), "filepath")
 		os.Setenv(fmt.Sprintf("%s_%s", corev1alpha1.InputConfigurationEnvVarPrefix, corev1alpha1.SidecarProviderArgsEnvVar), "key=value,key2=value2")
+		os.Setenv(fmt.Sprintf("%s_%s", corev1alpha1.InputConfigurationEnvVarPrefix, corev1alpha1.SidecarLogFormatEnvVar), "yaml")
 
 		pod := testPod(defaultPodName, defaultPodServiceAccountName, map[string]string{
 			"openfeature.dev":                          "enabled",
@@ -416,6 +419,7 @@ var _ = Describe("pod mutation webhook", func() {
 			{Name: "MY_SIDECAR_PORT", Value: "20"},
 			{Name: "MY_SIDECAR_EVALUATOR", Value: "evaluator"},
 			{Name: "MY_SIDECAR_SOCKET_PATH", Value: "socket"},
+			{Name: "MY_SIDECAR_LOG_FORMAT", Value: "yaml"},
 		}))
 		Expect(pod.Spec.Containers[1].Image).To(Equal("image:version"))
 		Expect(pod.Spec.Containers[1].Args).To(Equal([]string{
@@ -440,6 +444,7 @@ var _ = Describe("pod mutation webhook", func() {
 		os.Setenv(fmt.Sprintf("%s_%s", corev1alpha1.InputConfigurationEnvVarPrefix, corev1alpha1.SidecarVersionEnvVar), "")
 		os.Setenv(fmt.Sprintf("%s_%s", corev1alpha1.InputConfigurationEnvVarPrefix, corev1alpha1.SidecarDefaultSyncProviderEnvVar), "")
 		os.Setenv(fmt.Sprintf("%s_%s", corev1alpha1.InputConfigurationEnvVarPrefix, corev1alpha1.SidecarProviderArgsEnvVar), "key=value,key2=value2")
+		os.Setenv(fmt.Sprintf("%s_%s", corev1alpha1.InputConfigurationEnvVarPrefix, corev1alpha1.SidecarLogFormatEnvVar), "")
 
 		pod := testPod(defaultPodName, defaultPodServiceAccountName, map[string]string{
 			"openfeature.dev":                         "enabled",
@@ -454,6 +459,7 @@ var _ = Describe("pod mutation webhook", func() {
 			{Name: "FLAGD_PORT", Value: "8080"},
 			{Name: "FLAGD_EVALUATOR", Value: "yaml"},
 			{Name: "FLAGD_SOCKET_PATH", Value: "/tmp/flag-source.sock"},
+			{Name: "FLAGD_LOG_FORMAT", Value: "console"},
 		}))
 		Expect(pod.Spec.Containers[1].Image).To(Equal("new-image:latest"))
 		Expect(pod.Spec.Containers[1].Args).To(Equal([]string{


### PR DESCRIPTION
## This PR
- adds a new `sidecarConfiguration.logFormat` helm value that is handed over to the operator as an env var
- sets the default sidecar log format to json both in code and in the CRD itself, as well as the helm chart

Fixes #334

