### PR TITLE
chore: debug flakey test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v ./webhooks
 
 ## Requires the operator to be deployed
 .PHONY: e2e-test

--- a/loop-test.sh
+++ b/loop-test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+$@
+while [ $? -eq 0 ]; do
+    $@
+done

--- a/webhooks/suite_test.go
+++ b/webhooks/suite_test.go
@@ -28,7 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	// +kubebuilder:scaffold:imports
@@ -61,9 +60,11 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
-	By("bootstrapping test environment")
+	logger := ctrl.Log.WithName("BeforeSuite")
+
+	logger.Info("bootstrapping test environment")
 	mutateFailPolicy := admissionv1.Ignore
 	validateFailPolicy := admissionv1.Fail
 	mutateSideEffects := admissionv1.SideEffectClassNoneOnDryRun
@@ -162,13 +163,11 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).ToNot(BeNil())
 
 	// deploy 'before' resources
-	By("setting up previously existing pod (BackfillPermissions test)")
+	logger.Info("setting up previously existing pod (BackfillPermissions test)")
 	setupPreviouslyExistingPods()
 
 	// setup webhook server
-	By("Setup webhook server")
-
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	logger.Info("setup webhook server")
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:             scheme,
@@ -209,7 +208,7 @@ var _ = BeforeSuite(func() {
 	})
 
 	// start webhook server
-	By("running webhook server")
+	logger.Info("running webhook server")
 
 	go func() {
 		err := mgr.Start(testCtx)
@@ -240,7 +239,7 @@ var _ = BeforeSuite(func() {
 		return podMutator.IsReady(nil)
 	}).Should(Succeed())
 
-	By("setting up resources")
+	logger.Info("setting up resources")
 	setupMutatePodResources()
 	setupValidateFeatureFlagConfigurationResources()
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Debugging of flakey test.

Reproduce failure by running `./loop-test.sh make test` and waiting.

Logs produced when test fails:
```
1.6765525704391098e+09  DEBUG   mutating-pod-webhook    backfilling permissions for pod test-mutate-pod/existing-pod-2
1.6765525704391522e+09  DEBUG   mutating-pod-webhook    Fetching serviceAccount: test-mutate-pod/existing-pod-2-service-account
1.6765525705403242e+09  DEBUG   mutating-pod-webhook    Fetching clusterrolebinding: open-feature-operator-flagd-kubernetes-sync
1.6765525706415858e+09  DEBUG   mutating-pod-webhook    Updating ClusterRoleBinding open-feature-operator-flagd-kubernetes-sync for service account: test-mutate-pod/existing-pod-2-service-account
1.6765525706420648e+09  DEBUG   mutating-pod-webhook    Updating ClusterRoleBinding {TypeMeta:{Kind:ClusterRoleBinding APIVersion:rbac.authorization.k8s.io/v1} ObjectMeta:{Name:open-feature-operator-flagd-kubernetes-sync GenerateName: Namespace: SelfLink: UID:9569f38b-260c-48b3-92ce-52df9f81f322 ResourceVersion:207 Generation:0 CreationTimestamp:2023-02-16 13:02:49 +0000 GMT DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ManagedFields:[{Manager:webhooks.test Operation:Update APIVersion:rbac.authorization.k8s.io/v1 Time:2023-02-16 13:02:49 +0000 GMT FieldsType:FieldsV1 FieldsV1:{"f:roleRef":{}} Subresource:}]} Subjects:[{Kind:ServiceAccount APIGroup: Name:existing-pod-2-service-account Namespace:test-mutate-pod}] RoleRef:{APIGroup:rbac.authorization.k8s.io Kind:ClusterRole Name:open-feature-operator-flagd-kubernetes-sync}}
1.676552570645508e+09   DEBUG   mutating-pod-webhook    Updated ClusterRoleBinding: open-feature-operator-flagd-kubernetes-sync
1.6765525706455722e+09  DEBUG   mutating-pod-webhook    Latest ClusterRoleBinding: {TypeMeta:{Kind:ClusterRoleBinding APIVersion:rbac.authorization.k8s.io/v1} ObjectMeta:{Name:open-feature-operator-flagd-kubernetes-sync GenerateName: Namespace: SelfLink: UID:9569f38b-260c-48b3-92ce-52df9f81f322 ResourceVersion:207 Generation:0 CreationTimestamp:2023-02-16 13:02:49 +0000 GMT DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ManagedFields:[{Manager:webhooks.test Operation:Update APIVersion:rbac.authorization.k8s.io/v1 Time:2023-02-16 13:02:49 +0000 GMT FieldsType:FieldsV1 FieldsV1:{"f:roleRef":{}} Subresource:}]} Subjects:[] RoleRef:{APIGroup:rbac.authorization.k8s.io Kind:ClusterRole Name:open-feature-operator-flagd-kubernetes-sync}}
1.6765525706455748e+09  DEBUG   mutating-pod-webhook    backfilling permissions for pod test-mutate-pod/existing-pod-1
1.676552570645577e+09   DEBUG   mutating-pod-webhook    Fetching serviceAccount: test-mutate-pod/existing-pod-1-service-account
1.676552570645581e+09   DEBUG   mutating-pod-webhook    Fetching clusterrolebinding: open-feature-operator-flagd-kubernetes-sync
1.6765525706455839e+09  DEBUG   mutating-pod-webhook    Updating ClusterRoleBinding open-feature-operator-flagd-kubernetes-sync for service account: test-mutate-pod/existing-pod-1-service-account
1.676552570645598e+09   DEBUG   mutating-pod-webhook    Updating ClusterRoleBinding {TypeMeta:{Kind:ClusterRoleBinding APIVersion:rbac.authorization.k8s.io/v1} ObjectMeta:{Name:open-feature-operator-flagd-kubernetes-sync GenerateName: Namespace: SelfLink: UID:9569f38b-260c-48b3-92ce-52df9f81f322 ResourceVersion:207 Generation:0 CreationTimestamp:2023-02-16 13:02:49 +0000 GMT DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ManagedFields:[{Manager:webhooks.test Operation:Update APIVersion:rbac.authorization.k8s.io/v1 Time:2023-02-16 13:02:49 +0000 GMT FieldsType:FieldsV1 FieldsV1:{"f:roleRef":{}} Subresource:}]} Subjects:[{Kind:ServiceAccount APIGroup: Name:existing-pod-1-service-account Namespace:test-mutate-pod}] RoleRef:{APIGroup:rbac.authorization.k8s.io Kind:ClusterRole Name:open-feature-operator-flagd-kubernetes-sync}}
1.676552570647946e+09   DEBUG   mutating-pod-webhook    Failed to update ClusterRoleBinding: Operation cannot be fulfilled on clusterrolebindings.rbac.authorization.k8s.io "open-feature-operator-flagd-kubernetes-sync": the object has been modified; please apply your changes to the latest version and try again
1.676552570648004e+09   DEBUG   mutating-pod-webhook    ClusterRoleBinding to update: {TypeMeta:{Kind:ClusterRoleBinding APIVersion:rbac.authorization.k8s.io/v1} ObjectMeta:{Name:open-feature-operator-flagd-kubernetes-sync GenerateName: Namespace: SelfLink: UID:9569f38b-260c-48b3-92ce-52df9f81f322 ResourceVersion:207 Generation:0 CreationTimestamp:2023-02-16 13:02:49 +0000 GMT DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ManagedFields:[{Manager:webhooks.test Operation:Update APIVersion:rbac.authorization.k8s.io/v1 Time:2023-02-16 13:02:49 +0000 GMT FieldsType:FieldsV1 FieldsV1:{"f:roleRef":{}} Subresource:}]} Subjects:[{Kind:ServiceAccount APIGroup: Name:existing-pod-1-service-account Namespace:test-mutate-pod}] RoleRef:{APIGroup:rbac.authorization.k8s.io Kind:ClusterRole Name:open-feature-operator-flagd-kubernetes-sync}}
1.6765525706480289e+09  DEBUG   mutating-pod-webhook    Latest ClusterRoleBinding: {TypeMeta:{Kind:ClusterRoleBinding APIVersion:rbac.authorization.k8s.io/v1} ObjectMeta:{Name:open-feature-operator-flagd-kubernetes-sync GenerateName: Namespace: SelfLink: UID:9569f38b-260c-48b3-92ce-52df9f81f322 ResourceVersion:210 Generation:0 CreationTimestamp:2023-02-16 13:02:49 +0000 GMT DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[] OwnerReferences:[] Finalizers:[] ManagedFields:[{Manager:webhooks.test Operation:Update APIVersion:rbac.authorization.k8s.io/v1 Time:2023-02-16 13:02:50 +0000 GMT FieldsType:FieldsV1 FieldsV1:{"f:roleRef":{},"f:subjects":{}} Subresource:}]} Subjects:[{Kind:ServiceAccount APIGroup: Name:existing-pod-2-service-account Namespace:test-mutate-pod}] RoleRef:{APIGroup:rbac.authorization.k8s.io Kind:ClusterRole Name:open-feature-operator-flagd-kubernetes-sync}}
1.6765525706480331e+09  ERROR   mutating-pod-webhook    unable backfill permissions for pod test-mutate-pod/existing-pod-1      {"webhook": "metadata.annotations.openfeature.dev/enabled", "error": "Operation cannot be fulfilled on clusterrolebindings.rbac.authorization.k8s.io \"open-feature-operator-flagd-kubernetes-sync\": the object has been modified; please apply your changes to the latest version and try again"}
```

We can see from the logs that there is a race condition from calling `Update` on the k8sClient. In this failure case we are retrieving the same object used in the `Update` call straight after and we can see the object doesn't contain the fields applied in the previous step.

@james-milligan has been told of this being an inherit flaw of envtest, he is attempting to locate the resource that informed him of this.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #347 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

