### PR TITLE
chore: upgrade ENVTEST_K8S_VERSION to 1.26.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ KUSTOMIZE_OVERLAY ?= DEFAULT
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 FLAGD_VERSION=v0.3.4
 CHART_VERSION=v0.2.28# x-release-please-version
-ENVTEST_K8S_VERSION = 1.25
+ENVTEST_K8S_VERSION = 1.26.1
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- Upgrades ENVTEST_K8S_VERSION to 1.26.1

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->
Locally, using this version reduces test instability (it still fails but less frequently).

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

