### PR TITLE
feat: migrate to flagd startup argument sources 

### DIFF
--- a/apis/core/v1alpha1/featureflagconfiguration_webhook.go
+++ b/apis/core/v1alpha1/featureflagconfiguration_webhook.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import ctrl "sigs.k8s.io/controller-runtime"
 
+// SetupWebhookWithManager register webhook for FeatureFlagConfiguration. Links conversion hub to server
 func (r *FeatureFlagConfiguration) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).

--- a/apis/core/v1alpha1/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha1/flagsourceconfiguration_types.go
@@ -124,7 +124,7 @@ type FlagSourceConfigurationSpec struct {
 }
 
 type Source struct {
-	// Source is an URI of the flag sources
+	// Source is a URI of the flag sources
 	Source string `json:"source"`
 
 	// Provider type - kubernetes, http(s), grpc(s) or filepath

--- a/apis/core/v1alpha1/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha1/flagsourceconfiguration_types.go
@@ -53,6 +53,7 @@ const (
 	SyncProviderKubernetes           SyncProviderType = "kubernetes"
 	SyncProviderFilepath             SyncProviderType = "filepath"
 	SyncProviderHttp                 SyncProviderType = "http"
+	SyncProviderGrpc                 SyncProviderType = "grpc"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -362,6 +363,10 @@ func (s SyncProviderType) IsHttp() bool {
 
 func (s SyncProviderType) IsFilepath() bool {
 	return s == SyncProviderFilepath
+}
+
+func (s SyncProviderType) IsGrpc() bool {
+	return s == SyncProviderGrpc
 }
 
 func envVarKey(prefix string, suffix string) string {

--- a/apis/core/v1alpha1/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha1/flagsourceconfiguration_types.go
@@ -123,14 +123,28 @@ type FlagSourceConfigurationSpec struct {
 }
 
 type Source struct {
+	// Source is an URI of the flag sources
 	Source string `json:"source"`
+
+	// Provider type - kubernetes, http(s), grpc(s) or filepath
 	// +optional
 	Provider SyncProviderType `json:"provider"`
+
+	// HttpSyncBearerToken is a bearer token. Used by http(s) sync provider only
 	// +optional
 	HttpSyncBearerToken string `json:"httpSyncBearerToken"`
-	// LogFormat allows for the sidecar log format to be overridden, defaults to 'json'
+
+	// HttpSyncBearerToken is a path of a certificate to be used by grpc TLS connection(grpcs providers only)
 	// +optional
-	LogFormat string `json:"logFormat"`
+	CertPath string `json:"certPath"`
+
+	// ProviderID is an identifier to be used in grpc(s) provider
+	// +optional
+	ProviderID string `json:"providerID"`
+
+	// Selector is a flag configuration selector used by grpc(s) provider
+	// +optional
+	Selector string `json:"selector,omitempty"`
 }
 
 // FlagSourceConfigurationStatus defines the observed state of FlagSourceConfiguration

--- a/apis/core/v1alpha1/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha1/flagsourceconfiguration_types.go
@@ -135,7 +135,7 @@ type Source struct {
 	// +optional
 	HttpSyncBearerToken string `json:"httpSyncBearerToken"`
 
-	// HttpSyncBearerToken is a path of a certificate to be used by grpc TLS connection(grpcs providers only)
+	// CertPath is a path of a certificate to be used by grpc TLS connection(grpcs providers only)
 	// +optional
 	CertPath string `json:"certPath"`
 

--- a/apis/core/v1alpha1/flagsourceconfiguration_webhook.go
+++ b/apis/core/v1alpha1/flagsourceconfiguration_webhook.go
@@ -4,6 +4,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
+// SetupWebhookWithManager register webhook for FlagSourceConfiguration. Links conversion hub to server
 func (r *FlagSourceConfiguration) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).

--- a/apis/core/v1alpha2/flagsourceconfiguration_conversion_test.go
+++ b/apis/core/v1alpha2/flagsourceconfiguration_conversion_test.go
@@ -37,12 +37,15 @@ func TestFlagSourceConfiguration_ConvertFrom(t *testing.T) {
 					Evaluator:   "eval",
 					Image:       "img",
 					Tag:         "tag",
+					//
 					Sources: []v1alpha1.Source{
 						{
 							Source:              "source",
 							Provider:            "provider",
 							HttpSyncBearerToken: "token",
-							LogFormat:           "log2",
+							CertPath:            "/tmp/path",
+							ProviderID:          "myapp",
+							Selector:            "source=database",
 						},
 					},
 					EnvVars: []corev1.EnvVar{

--- a/apis/core/v1alpha3/flagsourceconfiguration_conversion.go
+++ b/apis/core/v1alpha3/flagsourceconfiguration_conversion.go
@@ -41,6 +41,9 @@ func (src *FlagSourceConfiguration) ConvertTo(dstRaw conversion.Hub) error {
 			Source:              sp.Source,
 			HttpSyncBearerToken: sp.HttpSyncBearerToken,
 			Provider:            v1alpha1.SyncProviderType(sp.Provider),
+			CertPath:            sp.CertPath,
+			ProviderID:          sp.ProviderID,
+			Selector:            sp.Selector,
 		})
 	}
 
@@ -77,8 +80,11 @@ func (dst *FlagSourceConfiguration) ConvertFrom(srcRaw conversion.Hub) error {
 	for _, sp := range src.Spec.Sources {
 		sources = append(sources, Source{
 			Source:              sp.Source,
-			Provider:            string(sp.Provider),
+			Provider:            SyncProviderType(sp.Provider),
 			HttpSyncBearerToken: sp.HttpSyncBearerToken,
+			CertPath:            sp.CertPath,
+			ProviderID:          sp.ProviderID,
+			Selector:            sp.Selector,
 		})
 	}
 

--- a/apis/core/v1alpha3/flagsourceconfiguration_conversion_test.go
+++ b/apis/core/v1alpha3/flagsourceconfiguration_conversion_test.go
@@ -42,7 +42,9 @@ func TestFlagSourceConfiguration_ConvertFrom(t *testing.T) {
 							Source:              "source",
 							Provider:            "provider",
 							HttpSyncBearerToken: "token",
-							LogFormat:           "log2",
+							CertPath:            "/tmp/path",
+							ProviderID:          "myapp",
+							Selector:            "source=database",
 						},
 					},
 					EnvVars: []corev1.EnvVar{
@@ -79,6 +81,9 @@ func TestFlagSourceConfiguration_ConvertFrom(t *testing.T) {
 							Source:              "source",
 							Provider:            "provider",
 							HttpSyncBearerToken: "token",
+							CertPath:            "/tmp/path",
+							ProviderID:          "myapp",
+							Selector:            "source=database",
 						},
 					},
 					EnvVars: []corev1.EnvVar{
@@ -148,6 +153,9 @@ func TestFlagSourceConfiguration_ConvertTo(t *testing.T) {
 							Source:              "source",
 							Provider:            "provider",
 							HttpSyncBearerToken: "token",
+							CertPath:            "/tmp/path",
+							ProviderID:          "myapp",
+							Selector:            "source=database",
 						},
 					},
 					EnvVars: []corev1.EnvVar{
@@ -184,7 +192,9 @@ func TestFlagSourceConfiguration_ConvertTo(t *testing.T) {
 							Source:              "source",
 							Provider:            "provider",
 							HttpSyncBearerToken: "token",
-							LogFormat:           "",
+							CertPath:            "/tmp/path",
+							ProviderID:          "myapp",
+							Selector:            "source=database",
 						},
 					},
 					EnvVars: []corev1.EnvVar{

--- a/apis/core/v1alpha3/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha3/flagsourceconfiguration_types.go
@@ -91,7 +91,7 @@ type FlagSourceConfigurationSpec struct {
 }
 
 type Source struct {
-	// Source is an URI of the flag sources
+	// Source is a URI of the flag sources
 	Source string `json:"source"`
 
 	// Provider type - kubernetes, http(s), grpc(s) or filepath

--- a/apis/core/v1alpha3/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha3/flagsourceconfiguration_types.go
@@ -102,7 +102,7 @@ type Source struct {
 	// +optional
 	HttpSyncBearerToken string `json:"httpSyncBearerToken"`
 
-	// HttpSyncBearerToken is a path of a certificate to be used by grpc TLS connection(grpcs providers only)
+	// CertPath is a path of a certificate to be used by grpc TLS connection(grpcs providers only)
 	// +optional
 	CertPath string `json:"certPath"`
 

--- a/apis/core/v1alpha3/flagsourceconfiguration_types.go
+++ b/apis/core/v1alpha3/flagsourceconfiguration_types.go
@@ -91,11 +91,28 @@ type FlagSourceConfigurationSpec struct {
 }
 
 type Source struct {
+	// Source is an URI of the flag sources
 	Source string `json:"source"`
+
+	// Provider type - kubernetes, http(s), grpc(s) or filepath
 	// +optional
-	Provider string `json:"provider"`
+	Provider SyncProviderType `json:"provider"`
+
+	// HttpSyncBearerToken is a bearer token. Used by http(s) sync provider only
 	// +optional
 	HttpSyncBearerToken string `json:"httpSyncBearerToken"`
+
+	// HttpSyncBearerToken is a path of a certificate to be used by grpc TLS connection(grpcs providers only)
+	// +optional
+	CertPath string `json:"certPath"`
+
+	// ProviderID is an identifier to be used in grpc(s) provider
+	// +optional
+	ProviderID string `json:"providerID"`
+
+	// Selector is a flag configuration selector used by grpc(s) provider
+	// +optional
+	Selector string `json:"selector,omitempty"`
 }
 
 // FlagSourceConfigurationStatus defines the observed state of FlagSourceConfiguration

--- a/config/crd/bases/core.openfeature.dev_flagsourceconfigurations.yaml
+++ b/config/crd/bases/core.openfeature.dev_flagsourceconfigurations.yaml
@@ -194,15 +194,28 @@ spec:
                   to be applied to the sidecar
                 items:
                   properties:
-                    httpSyncBearerToken:
+                    certPath:
+                      description: HttpSyncBearerToken is a path of a certificate
+                        to be used by grpc TLS connection(grpcs providers only)
                       type: string
-                    logFormat:
-                      description: LogFormat allows for the sidecar log format to
-                        be overridden, defaults to 'json'
+                    httpSyncBearerToken:
+                      description: HttpSyncBearerToken is a bearer token. Used by
+                        http(s) sync provider only
                       type: string
                     provider:
+                      description: Provider type - kubernetes, http(s), grpc(s) or
+                        filepath
+                      type: string
+                    providerID:
+                      description: ProviderID is an identifier to be used in grpc(s)
+                        provider
+                      type: string
+                    selector:
+                      description: Selector is a flag configuration selector used
+                        by grpc(s) provider
                       type: string
                     source:
+                      description: Source is an URI of the flag sources
                       type: string
                   required:
                   - source
@@ -480,11 +493,28 @@ spec:
                   configuration to be applied to the sidecar
                 items:
                   properties:
+                    certPath:
+                      description: HttpSyncBearerToken is a path of a certificate
+                        to be used by grpc TLS connection(grpcs providers only)
+                      type: string
                     httpSyncBearerToken:
+                      description: HttpSyncBearerToken is a bearer token. Used by
+                        http(s) sync provider only
                       type: string
                     provider:
+                      description: Provider type - kubernetes, http(s), grpc(s) or
+                        filepath
+                      type: string
+                    providerID:
+                      description: ProviderID is an identifier to be used in grpc(s)
+                        provider
+                      type: string
+                    selector:
+                      description: Selector is a flag configuration selector used
+                        by grpc(s) provider
                       type: string
                     source:
+                      description: Source is an URI of the flag sources
                       type: string
                   required:
                   - source

--- a/docs/flag_source_configuration.md
+++ b/docs/flag_source_configuration.md
@@ -57,11 +57,14 @@ The relevant `FlagSourceConfigurations` are passed to the operator by setting th
 
 ## Source Fields
 
-| Field               | Behavior                                                                                                                              | Type              | 
-|---------------------|---------------------------------------------------------------------------------------------------------------------------------------|-------------------|
-| Source              | Defines the URI of the flag source, this can be either a `host:port` or the `namespace/name` of a `FeatureFlagConfiguration`          | `string`          |
-| Provider            | Defines the provider to be used, can be set to `kubernetes`, `filepath` or `http`. If not provided the default sync provider is used. | optional `string` |
-| HttpSyncBearerToken | Defines the bearer token to be used with a `http` sync. Has no effect if `Provider` is not `http`                                     | optional `string` |
+| Field               | Behavior                                                                                                                                            | Type              | 
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
+| Source              | Defines the URI of the flag source, this can be either a `host:port` or the `namespace/name` of a `FeatureFlagConfiguration`                        | `string`          |
+| Provider            | Defines the provider to be used, can be set to `kubernetes`, `filepath`, `http(s)` or `grpc(s)`. If not provided the default sync provider is used. | optional `string` |
+| HttpSyncBearerToken | Defines the bearer token to be used with a `http` sync. Has no effect if `Provider` is not `http`                                                   | optional `string` |
+| CertPath            | Defines the certificate path to be used by grpc TLS connectivity(grpcs). Has no effect on other `Provider` types                                    | optional `string` |
+| ProviderID          | Defines the identifier for grpc(s) connection. Has no effect on other `Provider` types                                                              | optional `string` |
+| Selector            | Defines the flag configuration selection criteria for grpc(s) connection. Has no effect on other `Provider` types                                   | optional `string` |
 
 ## Configuration Merging
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -118,10 +118,10 @@ kubectl describe pod busybox-curl-7bd5767999-spf7v
     Image: ghcr.io/open-feature/flagd:v0.4.4
     Port: 8014/TCP
     Host Port: 0/TCP
-    Args:
-      start
-      --uri
-      core.openfeature.dev/default/featureflagconfiguration-sample
+    -args:
+      - start
+      - --sources
+      - '[{"uri":"core.openfeature.dev/default/featureflagconfiguration-sample","provider":"kubernetes"}]'
     Environment:
       FLAGD_METRICS_PORT: 8014
 ```

--- a/pkg/types/SourceConfig.go
+++ b/pkg/types/SourceConfig.go
@@ -1,0 +1,14 @@
+package types
+
+// SourceConfig is a 1:1 mapping for flagd SourceConfig type. JSON encoded SourceConfig becomes a startup argument for
+// flagd
+// NOTE - once we have API stability, make this a dependency at flagd to avoid duplication
+type SourceConfig struct {
+	URI      string `json:"uri"`
+	Provider string `json:"provider"`
+
+	BearerToken string `json:"bearerToken,omitempty"`
+	CertPath    string `json:"certPath,omitempty"`
+	ProviderID  string `json:"providerID,omitempty"`
+	Selector    string `json:"selector,omitempty"`
+}

--- a/webhooks/pod_webhook.go
+++ b/webhooks/pod_webhook.go
@@ -370,7 +370,8 @@ func (m *PodMutator) handleFilepathProvider(ctx context.Context,
 			mountPath,
 			v1alpha1.FeatureFlagConfigurationConfigMapKey(ns, n),
 		),
-		Provider: string(v1alpha1.SyncProviderFilepath),
+		// todo - this constant needs to be aligned with flagd. We have a mixed usage of file vs filepath
+		Provider: "file",
 	}, nil
 }
 

--- a/webhooks/pod_webhook_test.go
+++ b/webhooks/pod_webhook_test.go
@@ -534,7 +534,7 @@ var _ = Describe("pod mutation webhook", func() {
 		Expect(pod.Spec.Containers[1].Args).To(Equal([]string{
 			"start",
 			SourceConfigParam,
-			"[{\"uri\":\"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration/test-mutate-pod_test-feature-flag-configuration.flagd.json\",\"provider\":\"filepath\"}]",
+			"[{\"uri\":\"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration/test-mutate-pod_test-feature-flag-configuration.flagd.json\",\"provider\":\"file\"}]",
 			"--sync-provider-args",
 			"key=value",
 			"--sync-provider-args",
@@ -618,7 +618,7 @@ var _ = Describe("pod mutation webhook", func() {
 			SourceConfigParam,
 			"[{\"uri\":\"core.openfeature.dev/test-mutate-pod/test-feature-flag-configuration\",\"provider\":\"kubernetes\"}," +
 				"{\"uri\":\"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration-2/test-mutate-pod_test-feature-flag-configuration-2.flagd.json\"," +
-				"\"provider\":\"filepath\"}]",
+				"\"provider\":\"file\"}]",
 		}))
 		Expect(pod.Spec.Containers[1].ImagePullPolicy).To(Equal(FlagDImagePullPolicy))
 		Expect(pod.Spec.Containers[1].Ports).To(Equal([]corev1.ContainerPort{
@@ -665,8 +665,8 @@ var _ = Describe("pod mutation webhook", func() {
 			"start",
 			SourceConfigParam,
 			"[{\"uri\":\"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration/test-mutate-pod_test-feature-flag-configuration.flagd.json\"," +
-				"\"provider\":\"filepath\"},{\"uri\":\"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration-2/test-mutate-pod_test-feature-flag-configuration-2.flagd.json\"," +
-				"\"provider\":\"filepath\"}]",
+				"\"provider\":\"file\"},{\"uri\":\"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration-2/test-mutate-pod_test-feature-flag-configuration-2.flagd.json\"," +
+				"\"provider\":\"file\"}]",
 		}))
 		podMutationWebhookCleanup()
 	})

--- a/webhooks/pod_webhook_test.go
+++ b/webhooks/pod_webhook_test.go
@@ -26,6 +26,7 @@ const (
 	flagSourceConfigurationName    = "test-flag-source-configuration"
 	flagSourceConfigurationName2   = "test-flag-source-configuration-2"
 	flagSourceConfigurationName3   = "test-flag-source-configuration-3"
+	flagSourceConfigGrpc           = "tes-flag-source-grpc"
 	existingPod1Name               = "existing-pod-1"
 	existingPod1ServiceAccountName = "existing-pod-1-service-account"
 	existingPod2Name               = "existing-pod-2"
@@ -155,6 +156,21 @@ func setupMutatePodResources() {
 		},
 	}
 	err = k8sClient.Create(testCtx, fsConfig3)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	fsConfigGrpc := &v1alpha1.FlagSourceConfiguration{}
+	fsConfigGrpc.Namespace = mutatePodNamespace
+	fsConfigGrpc.Name = flagSourceConfigGrpc
+	fsConfigGrpc.Spec.Sources = []v1alpha1.Source{
+		{
+			Source:     "grpc://grpc-service:9090",
+			Provider:   v1alpha1.SyncProviderGrpc,
+			ProviderID: "myapp",
+			Selector:   "source=database",
+			CertPath:   "/tmp/certs",
+		},
+	}
+	err = k8sClient.Create(testCtx, fsConfigGrpc)
 	Expect(err).ShouldNot(HaveOccurred())
 }
 
@@ -306,7 +322,7 @@ var _ = Describe("pod mutation webhook", func() {
 		Expect(pod.Spec.Containers[1].Name).To(Equal("flagd"))
 		Expect(pod.Spec.Containers[1].Image).To(Equal(fmt.Sprintf("%s:%s", flagConfig.Image, flagConfig.Tag)))
 		Expect(pod.Spec.Containers[1].Args).To(Equal([]string{
-			"start", "--uri", fmt.Sprintf("core.openfeature.dev/%s/%s", mutatePodNamespace, featureFlagConfigurationName),
+			"start", SourceConfigParam, "[{\"uri\":\"core.openfeature.dev/test-mutate-pod/test-feature-flag-configuration\",\"provider\":\"kubernetes\"}]",
 		}))
 		Expect(pod.Spec.Containers[1].ImagePullPolicy).To(Equal(FlagDImagePullPolicy))
 		Expect(pod.Spec.Containers[1].Env).To(Equal([]corev1.EnvVar{
@@ -517,8 +533,8 @@ var _ = Describe("pod mutation webhook", func() {
 		Expect(pod.Spec.Containers[1].Image).To(Equal("image:version"))
 		Expect(pod.Spec.Containers[1].Args).To(Equal([]string{
 			"start",
-			"--uri",
-			"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration/test-mutate-pod_test-feature-flag-configuration.flagd.json",
+			SourceConfigParam,
+			"[{\"uri\":\"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration/test-mutate-pod_test-feature-flag-configuration.flagd.json\",\"provider\":\"filepath\"}]",
 			"--sync-provider-args",
 			"key=value",
 			"--sync-provider-args",
@@ -562,8 +578,8 @@ var _ = Describe("pod mutation webhook", func() {
 		Expect(pod.Spec.Containers[1].Image).To(Equal("new-image:latest"))
 		Expect(pod.Spec.Containers[1].Args).To(Equal([]string{
 			"start",
-			"--uri",
-			"not-real.com",
+			SourceConfigParam,
+			"[{\"uri\":\"not-real.com\",\"provider\":\"http\"}]",
 			"--sync-provider-args",
 			"key=value",
 			"--sync-provider-args",
@@ -599,10 +615,10 @@ var _ = Describe("pod mutation webhook", func() {
 		Expect(pod.Spec.Containers[1].Image).To(Equal(fmt.Sprintf("%s:%s", flagConfig.Image, flagConfig.Tag)))
 		Expect(pod.Spec.Containers[1].Args).To(Equal([]string{
 			"start",
-			"--uri",
-			"core.openfeature.dev/test-mutate-pod/test-feature-flag-configuration",
-			"--uri",
-			"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration-2/test-mutate-pod_test-feature-flag-configuration-2.flagd.json",
+			SourceConfigParam,
+			"[{\"uri\":\"core.openfeature.dev/test-mutate-pod/test-feature-flag-configuration\",\"provider\":\"kubernetes\"}," +
+				"{\"uri\":\"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration-2/test-mutate-pod_test-feature-flag-configuration-2.flagd.json\"," +
+				"\"provider\":\"filepath\"}]",
 		}))
 		Expect(pod.Spec.Containers[1].ImagePullPolicy).To(Equal(FlagDImagePullPolicy))
 		Expect(pod.Spec.Containers[1].Ports).To(Equal([]corev1.ContainerPort{
@@ -647,10 +663,27 @@ var _ = Describe("pod mutation webhook", func() {
 		pod = getPod(defaultPodName)
 		Expect(pod.Spec.Containers[1].Args).To(Equal([]string{
 			"start",
-			"--uri",
-			"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration/test-mutate-pod_test-feature-flag-configuration.flagd.json",
-			"--uri",
-			"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration-2/test-mutate-pod_test-feature-flag-configuration-2.flagd.json",
+			SourceConfigParam,
+			"[{\"uri\":\"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration/test-mutate-pod_test-feature-flag-configuration.flagd.json\"," +
+				"\"provider\":\"filepath\"},{\"uri\":\"file:/etc/flagd/test-mutate-pod_test-feature-flag-configuration-2/test-mutate-pod_test-feature-flag-configuration-2.flagd.json\"," +
+				"\"provider\":\"filepath\"}]",
+		}))
+		podMutationWebhookCleanup()
+	})
+
+	It("should create a valid grpc source configuration", func() {
+		pod := testPod(defaultPodName, defaultPodServiceAccountName, map[string]string{
+			OpenFeatureAnnotationPrefix: "enabled",
+			fmt.Sprintf("%s/%s", OpenFeatureAnnotationPrefix, FlagSourceConfigurationAnnotation): fmt.Sprintf("%s/%s", mutatePodNamespace, flagSourceConfigGrpc),
+		})
+		err := k8sClient.Create(testCtx, pod)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		pod = getPod(defaultPodName)
+		Expect(pod.Spec.Containers[1].Args).To(Equal([]string{
+			"start",
+			SourceConfigParam,
+			"[{\"uri\":\"grpc://grpc-service:9090\",\"provider\":\"grpc\",\"certPath\":\"/tmp/certs\",\"providerID\":\"myapp\",\"selector\":\"source=database\"}]",
 		}))
 		podMutationWebhookCleanup()
 	})


### PR DESCRIPTION
## This PR

Fixes #389 

This PR migrate flagd side-car startup arguments from `uri` (`flagd start --uri <sync-source>`) to `sources` (`flagd start --sources <sync-source>`).

More on the new `sources` based configuration options [1]

With this option, I have introduced the grpc sync option to OFO and other grpc sync-provider options. 

### follow-up

Discussion - type `SourceConfig` can be referred from OFO dependency and avoid duplication at flagd

[1] - https://github.com/open-feature/flagd/blob/main/docs/configuration/configuration.md