### PR TITLE
chore: improve container build layer caching

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -127,6 +127,8 @@ jobs:
           context: .
           outputs: type=docker,dest=${{ github.workspace }}/open-feature-operator-local.tar
           tags: open-feature-operator-local:${{ github.sha }}
+          cache-from: type=gha,scope=${{ github.ref_name }}-ofo
+          cache-to: type=gha,scope=${{ github.ref_name }}-ofo
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -81,6 +81,8 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release-please.outputs.release_tag_name }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ github.ref_name }}-ofo
+          cache-to: type=gha,scope=${{ github.ref_name }}-ofo
 
 
       - name: Install cosign

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@
 FROM --platform=$BUILDPLATFORM golang:1.20.2-alpine3.16 AS builder
 
 WORKDIR /workspace
-ARG TARGETOS
-ARG TARGETARCH
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -18,12 +16,15 @@ COPY webhooks/ webhooks/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
+ARG TARGETOS
+ARG TARGETARCH
+
 # Build
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot as production
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
### This PR
- optimizes container builds by moving the reading of build arguments to right before they are needed
- with the next `RUN` command after an `ARG` command, the docker layer cache is always invalidated, since the RUN command can have different effects with different build args that the image builder cannot foresee.
- by moving the build arg steps further down in the dockerfile, caching should be improved by a lot
- I also enabled github actions caching for the docker builds to improve pipeline times