### PR TITLE
chore: fix renovate config, add recommended preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
   },
   "regexManagers": [
     {
-      "fileMatch": ["^apis/core/**/flagsourceconfiguration_types.go$"],
+      "fileMatch": ["^apis/core/.*/flagsourceconfiguration_types.go$"],
       "matchStrings": ["defaultTag\\s*string\\s*= \"(?<currentValue>.*?)\"\\n"],
       "depNameTemplate": "open-feature/flagd",
       "datasourceTemplate": "github-tags",

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "forkProcessing": "enabled",
   "extends": [
-    "config:base"
+    "config:base",
+    "group:recommended"
   ],
   "semanticCommits": "enabled",
   "labels": [
@@ -18,6 +19,14 @@
       "^config/default/.*-patch\\.yaml$"
     ]
   },
+  "packageRules": [
+    {
+      "matchDepPatterns": [
+        "^.*open-feature/flagd.*$"
+      ],
+      "groupName": "flagd"
+    }
+  ],
   "regexManagers": [
     {
       "fileMatch": ["^apis/core/.*/flagsourceconfiguration_types.go$"],

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
       "matchDepPatterns": [
         "^.*open-feature/flagd.*$"
       ],
-      "groupName": "flagd"
+      "groupName": "open-feature/flagd"
     }
   ],
   "regexManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -23,29 +23,25 @@
       "fileMatch": ["^apis/core/.*/flagsourceconfiguration_types.go$"],
       "matchStrings": ["defaultTag\\s*string\\s*= \"(?<currentValue>.*?)\"\\n"],
       "depNameTemplate": "open-feature/flagd",
-      "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^flagd/(?<version>.*)$"
+      "datasourceTemplate": "github-releases"
     },
     {
       "fileMatch": ["^chart/open-feature-operator/values.yaml$"],
       "matchStrings": ["repository: \"ghcr\\.io\/open-feature\/flagd\"\\n\\s*tag: (?<currentValue>.*?)\\n"],
       "depNameTemplate": "open-feature/flagd",
-      "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^flagd/(?<version>.*)$"
+      "datasourceTemplate": "github-releases"
     },
     {
       "fileMatch": ["^chart/open-feature-operator/README.md$"],
       "matchStrings": ["current flagd version: \\`(?<currentValue>.*?)\\`"],
       "depNameTemplate": "open-feature/flagd",
-      "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^flagd/(?<version>.*)$"
+      "datasourceTemplate": "github-releases"
     },
     {
       "fileMatch": ["^docs/getting_started.md$"],
       "matchStrings": ["ghcr\\.io\\/open-feature\\/flagd:(?<currentValue>.*?)\\n"],
       "depNameTemplate": "open-feature/flagd",
-      "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^flagd/(?<version>.*)$"
+      "datasourceTemplate": "github-releases"
     }
   ]
 

--- a/renovate.json
+++ b/renovate.json
@@ -22,25 +22,29 @@
       "fileMatch": ["^apis/core/**/flagsourceconfiguration_types.go$"],
       "matchStrings": ["defaultTag\\s*string\\s*= \"(?<currentValue>.*?)\"\\n"],
       "depNameTemplate": "open-feature/flagd",
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^flagd/(?<version>.*)$"
     },
     {
       "fileMatch": ["^chart/open-feature-operator/values.yaml$"],
       "matchStrings": ["repository: \"ghcr\\.io\/open-feature\/flagd\"\\n\\s*tag: (?<currentValue>.*?)\\n"],
       "depNameTemplate": "open-feature/flagd",
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^flagd/(?<version>.*)$"
     },
     {
       "fileMatch": ["^chart/open-feature-operator/README.md$"],
       "matchStrings": ["current flagd version: \\`(?<currentValue>.*?)\\`"],
       "depNameTemplate": "open-feature/flagd",
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^flagd/(?<version>.*)$"
     },
     {
       "fileMatch": ["^docs/getting_started.md$"],
       "matchStrings": ["ghcr\\.io\\/open-feature\\/flagd:(?<currentValue>.*?)\\n"],
       "depNameTemplate": "open-feature/flagd",
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^flagd/(?<version>.*)$"
     }
   ]
 

--- a/renovate.json
+++ b/renovate.json
@@ -23,25 +23,29 @@
       "fileMatch": ["^apis/core/.*/flagsourceconfiguration_types.go$"],
       "matchStrings": ["defaultTag\\s*string\\s*= \"(?<currentValue>.*?)\"\\n"],
       "depNameTemplate": "open-feature/flagd",
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^flagd/(?<version>.*)$"
     },
     {
       "fileMatch": ["^chart/open-feature-operator/values.yaml$"],
       "matchStrings": ["repository: \"ghcr\\.io\/open-feature\/flagd\"\\n\\s*tag: (?<currentValue>.*?)\\n"],
       "depNameTemplate": "open-feature/flagd",
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^flagd/(?<version>.*)$"
     },
     {
       "fileMatch": ["^chart/open-feature-operator/README.md$"],
       "matchStrings": ["current flagd version: \\`(?<currentValue>.*?)\\`"],
       "depNameTemplate": "open-feature/flagd",
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^flagd/(?<version>.*)$"
     },
     {
       "fileMatch": ["^docs/getting_started.md$"],
       "matchStrings": ["ghcr\\.io\\/open-feature\\/flagd:(?<currentValue>.*?)\\n"],
       "depNameTemplate": "open-feature/flagd",
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^flagd/(?<version>.*)$"
     }
   ]
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "forkProcessing": "enabled",
   "extends": [
     "config:base"
   ],


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- fixes the current renovate config to get flagd renovate updates to work again
- enables the `group:recommended` preset so that common monorepo and grouped packages are put into one PR per group (e.g. k8s API packages, or angular monorepo packages)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #415

### Notes
Result of the config change can be seen in my fork.
Working renovate PR to update flagd: https://github.com/mowies/open-feature-operator/pull/9
Renovate deps dashboard from my fork: https://github.com/mowies/open-feature-operator/issues/4


