### PR TITLE
fix: demonstration of service naming bug

### DIFF
--- a/config/rbac/flagd_kubernetes_sync_clusterrolebinding.yaml
+++ b/config/rbac/flagd_kubernetes_sync_clusterrolebinding.yaml
@@ -7,6 +7,10 @@ subjects:
   name: open-feature-operator-controller-manager
   namespace: system
   apiGroup: ""
+- kind: ServiceAccount
+  name: default
+  namespace: open-feature-operator-system
+  apiGroup: ""
 roleRef:
   kind: ClusterRole
   name: open-feature-operator-flagd-kubernetes-sync

--- a/config/samples/dev.yaml
+++ b/config/samples/dev.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: core.openfeature.dev/v1alpha2
+kind: FeatureFlagConfiguration
+metadata:
+  name: end-to-end
+spec:
+  featureFlagSpec:
+    flags:
+      new-welcome-message:
+        state: ENABLED
+        variants:
+          "on": true
+          "off": false
+        defaultVariant: "on"
+      hex-color:
+        state: ENABLED
+        variants:
+          red: "#CC0000"
+          green: "#00CC00"
+          blue: "#0000CC"
+          yellow: yellow
+        defaultVariant: green
+      fib-algo:
+        state: ENABLED
+        variants:
+          recursive: recursive
+          memo: memo
+          loop: loop
+          binet: binet
+        defaultVariant: recursive
+        "targeting": {
+          "if": [
+            {
+              "in": [ "@faas.com", {
+                "var": [ "email" ]
+              } ]
+            }, "binet", null
+          ]
+        }
+---
+apiVersion: core.openfeature.dev/v1alpha3
+kind: FlagSourceConfiguration
+metadata:
+  name: end-to-end
+spec:
+  sources:
+    - source: default/end-to-end
+      provider: kubernetes
+  envVars:
+    - name: FLAGD_CORS_ORIGIN
+      value: "http://ofoclientapp.com:8080"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: flagd
+  namespace: open-feature-operator-system
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8013
+  selector:
+    flagd: open-feature-dev-flagd
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flagd
+  namespace: open-feature-operator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: flagd
+  template:
+    metadata:
+      labels:
+        app: flagd
+    spec:
+      serviceAccountName: default
+      containers:
+        - image: ghcr.io/open-feature/flagd:v0.4.4
+          imagePullPolicy: Always
+          name: flagd
+          ports:
+            - containerPort: 8013
+          args:
+            - start
+            - --uri
+            - core.openfeature.dev/default/end-to-end
+---


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Demonstrates a bug found where naming a Service `flagd` causes the networking of a flagd Deployment to break.

To reproduce, checkout this branch and follow these steps:

```bash
# using kind or minikube produces the same result
kind create cluster --config ./test/e2e/kind-cluster.yml
IMG=ghcr.io/open-feature/open-feature-operator:local ARCH=arm64 make docker-build
kind load docker-image ghcr.io/open-feature/open-feature-operator:local
IMG=ghcr.io/open-feature/open-feature-operator:local make deploy-operator
kubectl apply -f config/samples/dev.yaml
# find the name of the flagd pod out of the following output
kubectl -n open-feature-operator-system get pods
# substitute with the name of the flagd pod
kubectl -n open-feature-operator-system port-forward pod/{POD_NAME} 8080:8013
# open a new terminal
curl -i -X POST "http://localhost:8080/schema.v1.Service/ResolveBoolean" -d "{\"flagKey\":\"new-welcome-message\",\"context\":{}}" -H "Content-Type: application/json"
```

You ought to see the following as the result of the curl
```
curl: (52) Empty reply from server
```
Then if you go back to the port forwarding terminal you ought to see something similar to 
```
Forwarding from 127.0.0.1:8080 -> 8013
Forwarding from [::1]:8080 -> 8013
Handling connection for 8080
E0330 14:46:28.642153   54378 portforward.go:406] an error occurred forwarding 8080 -> 8013: error forwarding port 8013 to pod 8a2b29d743231078a3850137cc89aee0de19d3dfc601030eea11e151447e4896, uid : failed to execute portforward in network namespace "/var/run/netns/cni-ed603c22-26f0-dd6b-21bc-e7776980c051": failed to connect to localhost:8013 inside namespace "8a2b29d743231078a3850137cc89aee0de19d3dfc601030eea11e151447e4896", IPv4: dial tcp4 127.0.0.1:8013: connect: connection refused IPv6 dial tcp6 [::1]:8013: connect: connection refused
E0330 14:46:28.642493   54378 portforward.go:234] lost connection to pod
```

Now, delete the cluster and rerun the previous steps but changing the name of the Service in `config/samples/dev.yaml` to anything but `flagd`. As a result of the curl you ought to see something similar to
```
HTTP/1.1 200 OK
Accept-Encoding: gzip
Content-Type: application/json
Vary: Origin
Date: Thu, 30 Mar 2023 13:50:08 GMT
Content-Length: 47

{"value":true,"reason":"STATIC","variant":"on"}%
```

Interestingly, if the Deployment exists prior to the Service creation it functions as expected.
Not sure how OFO is meddling here but I can't fathom any other reason for this to be happening.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #431

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

