### PR TITLE
chore: remove ignored renovate paths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,10 +8,6 @@
   "labels": [
     "renovate"
   ],
-  "ignorePaths": [
-    "**/test/**",
-    "**/tests/**"
-  ],
   "kubernetes": {
     "fileMatch": [
       "^chart/templates/rendered\\.yaml$",


### PR DESCRIPTION
## This PR

- removes ignored renovate paths

### Notes

Renovate must update some e2e test assertions when flagd is updated.
