### PR TITLE
fix: remove unneeded OF namespace prefix from clusterrolebindings

### DIFF
--- a/config/rbac/flagd_kubernetes_sync_clusterrolebinding.yaml
+++ b/config/rbac/flagd_kubernetes_sync_clusterrolebinding.yaml
@@ -4,14 +4,14 @@ metadata:
   name: flagd-kubernetes-sync
 subjects:
 - kind: ServiceAccount
-  name: open-feature-operator-controller-manager
+  name: controller-manager
   namespace: system
   apiGroup: ""
 - kind: ServiceAccount
-  name: open-feature-operator-flagd-proxy
+  name: flagd-proxy
   namespace: system
   apiGroup: ""
 roleRef:
   kind: ClusterRole
-  name: open-feature-operator-flagd-kubernetes-sync
+  name: flagd-kubernetes-sync
   apiGroup: ""


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- removes OF namespace prefix from clusterrolebindings -> this way kustomize kicks in and adds the prefix to the the resources


