### PR TITLE
fix: remove 'grpc://' prefix from proxy sync address

### DIFF
--- a/controllers/common/flagd-injector.go
+++ b/controllers/common/flagd-injector.go
@@ -287,7 +287,7 @@ func (fi *FlagdContainerInjector) toFlagdProxyConfig(ctx context.Context, object
 	return types.SourceConfig{
 		Provider: "grpc",
 		Selector: fmt.Sprintf("core.openfeature.dev/%s/%s", ns, n),
-		URI:      fmt.Sprintf("grpc://%s.%s.svc.cluster.local:%d", FlagdProxyServiceName, fi.FlagdProxyConfig.Namespace, fi.FlagdProxyConfig.Port),
+		URI:      fmt.Sprintf("%s.%s.svc.cluster.local:%d", FlagdProxyServiceName, fi.FlagdProxyConfig.Namespace, fi.FlagdProxyConfig.Port),
 	}, nil
 }
 

--- a/controllers/common/flagd-injector_test.go
+++ b/controllers/common/flagd-injector_test.go
@@ -549,7 +549,7 @@ func TestFlagdContainerInjector_InjectProxySource_ProxyIsReady(t *testing.T) {
 
 	expectedDeployment.Annotations = nil
 
-	expectedDeployment.Spec.Template.Spec.Containers[0].Args = []string{"start", "--sources", "[{\"uri\":\"grpc://flagd-proxy-svc.my-namespace.svc.cluster.local:8013\",\"provider\":\"grpc\",\"selector\":\"core.openfeature.dev/my-namespace/\"}]"}
+	expectedDeployment.Spec.Template.Spec.Containers[0].Args = []string{"start", "--sources", "[{\"uri\":\"flagd-proxy-svc.my-namespace.svc.cluster.local:8013\",\"provider\":\"grpc\",\"selector\":\"core.openfeature.dev/my-namespace/\"}]"}
 
 	require.Equal(t, expectedDeployment, deployment)
 }


### PR DESCRIPTION
This PR fixes the flagd proxy sync provider address by removing the `grpc://` prefix from the URL pointing to the flagd proxy service. This is required because otherwise the flagd sidecar will run into the following error:

```
2023-04-25T09:09:27.611Z	fatal	cmd/start.go:180	rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp: address grpc://flagd-proxy-svc.open-feature-operator-system.svc.cluster.local:8015: too many colons in address"	{"component": "start"}
```