### PR TITLE
chore: adapt ServiceAccount only in case of K8s Provider

### DIFF
--- a/webhooks/pod_webhook_test.go
+++ b/webhooks/pod_webhook_test.go
@@ -335,7 +335,19 @@ func TestPodMutator_Handle(t *testing.T) {
 		{
 			name: "forbidden request pod annotated with owner, but cluster role binding cannot be enabled",
 			mutator: &PodMutator{
-				Client:  NewClient(false),
+				Client: NewClient(false,
+					&v1alpha1.FeatureFlagConfiguration{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      featureFlagConfigurationName,
+							Namespace: mutatePodNamespace,
+						},
+						Spec: v1alpha1.FeatureFlagConfigurationSpec{
+							FlagDSpec: &v1alpha1.FlagDSpec{Envs: []corev1.EnvVar{
+								{Name: "LOG_LEVEL", Value: "dev"},
+							}},
+						},
+					},
+				),
 				decoder: decoder,
 				Log:     testr.New(t),
 				ready:   false,


### PR DESCRIPTION
Follow-up from the discussion https://github.com/open-feature/open-feature-operator/pull/497#discussion_r1259387714

## This PR

- the `RoleBinding` that attaches elevated permissions to the `ServiceAccount` of a Pod is created iff there is a K8s provider