### PR TITLE
fix: use admission webhook namespace if pod namespace is empty

### DIFF
--- a/webhooks/pod_webhook.go
+++ b/webhooks/pod_webhook.go
@@ -65,6 +65,11 @@ func (m *PodMutator) Handle(ctx context.Context, req admission.Request) admissio
 	}()
 	pod := &corev1.Pod{}
 	err := m.decoder.Decode(req, pod)
+
+	if pod.Namespace == "" {
+		pod.Namespace = req.Namespace
+	}
+
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Fix issue with admission webhook on older k8s version

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #500

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

We then can say open-feature-operator is working on k8s >= 1.22

### How to test

I tested on kind with a 1.22 image (`image: kindest/node:v1.22.9`) .

```shell
kind create cluster --config ./test/e2e/kind-cluster.yml
kind load docker-image local-image-tag:latest
IMG=local-image-tag:latest make deploy-operator
IMG=local-image-tag:latest make e2e-test
```

