### PR TITLE
chore: adapt API for sidecar image and tag restriction

### DIFF
--- a/apis/core/v1beta1/featureflagsource_types_test.go
+++ b/apis/core/v1beta1/featureflagsource_types_test.go
@@ -27,8 +27,6 @@ func Test_FLagSourceConfiguration_Merge(t *testing.T) {
 			Evaluator:      "evaluator",
 			SocketPath:     "socket-path",
 			LogFormat:      "log",
-			Image:          "img",
-			Tag:            "tag",
 			Sources: []Source{
 				{
 					Source:     "src1",
@@ -68,8 +66,6 @@ func Test_FLagSourceConfiguration_Merge(t *testing.T) {
 			Evaluator:      "evaluator",
 			SocketPath:     "socket-path",
 			LogFormat:      "log",
-			Image:          "img",
-			Tag:            "tag",
 			Sources: []Source{
 				{
 					Source:     "src1",
@@ -107,8 +103,6 @@ func Test_FLagSourceConfiguration_Merge(t *testing.T) {
 			Evaluator:      "evaluator1",
 			SocketPath:     "socket-path1",
 			LogFormat:      "log1",
-			Image:          "img1",
-			Tag:            "tag1",
 			Sources: []Source{
 				{
 					Source:   "src2",
@@ -152,8 +146,6 @@ func Test_FLagSourceConfiguration_Merge(t *testing.T) {
 			Evaluator:      "evaluator1",
 			SocketPath:     "socket-path1",
 			LogFormat:      "log1",
-			Image:          "img1",
-			Tag:            "tag1",
 			Sources: []Source{
 				{
 					Source:     "src1",
@@ -176,55 +168,6 @@ func Test_FLagSourceConfiguration_Merge(t *testing.T) {
 			OtelCollectorUri:    "",
 		},
 	}, ff_old)
-}
-
-func Test_FLagSourceConfiguration_NewFeatureFlagSourceSpec(t *testing.T) {
-	//happy path
-	t.Setenv(common.EnvVarKey(InputConfigurationEnvVarPrefix, SidecarMetricPortEnvVar), "22")
-	t.Setenv(common.EnvVarKey(InputConfigurationEnvVarPrefix, SidecarPortEnvVar), "33")
-	t.Setenv(common.EnvVarKey(InputConfigurationEnvVarPrefix, SidecarSocketPathEnvVar), "val1")
-	t.Setenv(common.EnvVarKey(InputConfigurationEnvVarPrefix, SidecarEvaluatorEnvVar), "val2")
-	t.Setenv(common.EnvVarKey(InputConfigurationEnvVarPrefix, SidecarImageEnvVar), "val3")
-	t.Setenv(common.EnvVarKey(InputConfigurationEnvVarPrefix, SidecarVersionEnvVar), "val4")
-	t.Setenv(common.EnvVarKey(InputConfigurationEnvVarPrefix, SidecarProviderArgsEnvVar), "val11,val22")
-	t.Setenv(common.EnvVarKey(InputConfigurationEnvVarPrefix, SidecarDefaultSyncProviderEnvVar), "kubernetes")
-	t.Setenv(common.EnvVarKey(InputConfigurationEnvVarPrefix, SidecarLogFormatEnvVar), "val5")
-	t.Setenv(SidecarEnvVarPrefix, "val6")
-	t.Setenv(common.EnvVarKey(InputConfigurationEnvVarPrefix, SidecarProbesEnabledVar), "true")
-
-	fs, err := NewFeatureFlagSourceSpec()
-
-	require.Nil(t, err)
-	require.Equal(t, &FeatureFlagSourceSpec{
-		ManagementPort:      22,
-		Port:                33,
-		SocketPath:          "val1",
-		Evaluator:           "val2",
-		Image:               "val3",
-		Tag:                 "val4",
-		Sources:             []Source{},
-		EnvVars:             []v1.EnvVar{},
-		SyncProviderArgs:    []string{"val11", "val22"},
-		DefaultSyncProvider: common.SyncProviderKubernetes,
-		EnvVarPrefix:        "val6",
-		LogFormat:           "val5",
-		ProbesEnabled:       common.TrueVal(),
-		DebugLogging:        common.FalseVal(),
-		OtelCollectorUri:    "",
-	}, fs)
-
-	//error paths
-	t.Setenv(common.EnvVarKey(InputConfigurationEnvVarPrefix, SidecarProbesEnabledVar), "blah")
-	_, err = NewFeatureFlagSourceSpec()
-	require.NotNil(t, err)
-
-	t.Setenv(common.EnvVarKey(InputConfigurationEnvVarPrefix, SidecarPortEnvVar), "blah")
-	_, err = NewFeatureFlagSourceSpec()
-	require.NotNil(t, err)
-
-	t.Setenv(common.EnvVarKey(InputConfigurationEnvVarPrefix, SidecarMetricPortEnvVar), "blah")
-	_, err = NewFeatureFlagSourceSpec()
-	require.NotNil(t, err)
 }
 
 func Test_FLagSourceConfiguration_ToEnvVars(t *testing.T) {


### PR DESCRIPTION
Part of #517 

Preparation for https://github.com/open-feature/open-feature-operator/pull/550

## Details

To restrict the setup of the sidecar image and tag, we need to remove the image and tag parameters from FFS CRD. These values will be read from the env variables of the operator deployment. Also the reading of the env variables should not happen in the CRD struct function, but should be handled in a common place for all env variable, for example in the `main.go`. Please see the [linked PR](https://github.com/open-feature/open-feature-operator/pull/550) for more details
