### PR TITLE
chore: ignore component for release tag and make release dependable

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,9 +40,9 @@ jobs:
       release_tag_name: ${{ steps.release.outputs.tag_name }}
 
   build-oci:
-    permissions:
-      packages: write # to push the container image 
     needs: release-please
+    permissions:
+      packages: write # to push the container image
     runs-on: ubuntu-22.04
     if: ${{ needs.release-please.outputs.release_created }}
     steps:
@@ -106,9 +106,9 @@ jobs:
         if: ${{ env.DRY_RUN != 'true' }}
 
   release-assets:
+    needs: build-oci
     permissions:
       contents: write  # for softprops/action-gh-release to create GitHub release
-    needs: release-please
     runs-on: ubuntu-22.04
     if: ${{ needs.release-please.outputs.release_created }}
     steps:
@@ -141,7 +141,7 @@ jobs:
               open-feature-operator-sbom.spdx.json
 
   release-charts:
-    needs: release-please
+    needs: release-assets
     permissions:
       contents: write
     runs-on: ubuntu-22.04

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,7 @@
     ".": {
       "release-type": "go",
       "package-name": "operator",
+      "include-component-in-tag": false,
       "draft": false,
       "prerelease": false,
       "bump-minor-pre-major": true,


### PR DESCRIPTION
## This PR

Improves CI by,

- ignoring component name in tag (experimental)
- make ci steps dependable on one another 