### PR TITLE
fix: use webhook ns if empty, more test versions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -98,7 +98,7 @@ jobs:
     needs: docker-local
     strategy:
       matrix:
-        node_image: [ v1.25.0, v1.26.0, v1.27.0 ]
+        node_image: [ v1.22.17, v1.23.17, v1.24.15, v1.25.11, v1.26.3, v1.27.3, v1.28.0 ]
     steps:
       - name: Install Go
         uses: actions/setup-go@v4

--- a/webhooks/pod_webhook.go
+++ b/webhooks/pod_webhook.go
@@ -51,6 +51,13 @@ func (m *PodMutator) Handle(ctx context.Context, req admission.Request) admissio
 	}()
 	pod := &corev1.Pod{}
 	err := m.decoder.Decode(req, pod)
+
+	// Fixes an issue with admission webhook on older k8s versions
+	// See: https://github.com/open-feature/open-feature-operator/issues/500
+	if pod.Namespace == "" {
+		pod.Namespace = req.Namespace
+	}
+
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}


### PR DESCRIPTION
## This PR

Reintroduces using admission webhook namespace if pod namespace is empty

### Related Issues

Fixes #500

### Notes

This was accidentally removed during a recent refactor. It wasn't caught in our tests because the oldest version that's tested is `1.25`. I've added a comment above the change to make it clear why this logic is there.
