### PR TITLE
chore: Remove metrics-port flag/usage from flagdproxy startup

### DIFF
--- a/common/flagdproxy/flagdproxy.go
+++ b/common/flagdproxy/flagdproxy.go
@@ -120,7 +120,7 @@ func (f *FlagdProxyHandler) newFlagdProxyManifest(ownerReferences []metav1.Owner
 	replicas := int32(1)
 	args := []string{
 		"start",
-		"--metrics-port",
+		"--management-port",
 		fmt.Sprintf("%d", f.config.ManagementPort),
 	}
 	if f.config.DebugLogging {
@@ -165,7 +165,7 @@ func (f *FlagdProxyHandler) newFlagdProxyManifest(ownerReferences []metav1.Owner
 									ContainerPort: int32(f.config.Port),
 								},
 								{
-									Name:          "metrics-port",
+									Name:          "management-port",
 									ContainerPort: int32(f.config.ManagementPort),
 								},
 							},

--- a/common/flagdproxy/flagdproxy_test.go
+++ b/common/flagdproxy/flagdproxy_test.go
@@ -208,7 +208,7 @@ func TestFlagdProxyHandler_HandleFlagdProxy_CreateProxy(t *testing.T) {
 	replicas := int32(1)
 	args := []string{
 		"start",
-		"--metrics-port",
+		"--management-port",
 		fmt.Sprintf("%d", 90),
 		"--debug",
 	}
@@ -256,7 +256,7 @@ func TestFlagdProxyHandler_HandleFlagdProxy_CreateProxy(t *testing.T) {
 									ContainerPort: int32(88),
 								},
 								{
-									Name:          "metrics-port",
+									Name:          "management-port",
 									ContainerPort: int32(90),
 								},
 							},


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Remove the usage of the metrics-port flag and and the corresponding tests.
This flag was deprecated and is now removed from flagd so it needs to be removed here before using the new version of flagd.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Closes #586 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

