### PR TITLE
feat: added interval to the openfeature api source

### DIFF
--- a/apis/core/v1beta1/featureflagsource_types.go
+++ b/apis/core/v1beta1/featureflagsource_types.go
@@ -138,6 +138,10 @@ type Source struct {
 	// Selector is a flag configuration selector used by grpc provider
 	// +optional
 	Selector string `json:"selector,omitempty"`
+
+	// Interval is a flag configuration interval used by http provider
+	// +optional
+	Interval uint32 `json:"interval,omitempty"`
 }
 
 // FeatureFlagSourceStatus defines the observed state of FeatureFlagSource

--- a/apis/core/v1beta1/featureflagsource_types.go
+++ b/apis/core/v1beta1/featureflagsource_types.go
@@ -139,7 +139,7 @@ type Source struct {
 	// +optional
 	Selector string `json:"selector,omitempty"`
 
-	// Interval is a flag configuration interval used by http provider
+	// Interval is a flag configuration interval in seconds used by http provider
 	// +optional
 	Interval uint32 `json:"interval,omitempty"`
 }

--- a/apis/core/v1beta1/featureflagsource_types_test.go
+++ b/apis/core/v1beta1/featureflagsource_types_test.go
@@ -35,6 +35,7 @@ func Test_FLagSourceConfiguration_Merge(t *testing.T) {
 					CertPath:   "etc/cert.ca",
 					ProviderID: "app",
 					Selector:   "source=database",
+					Interval:   5,
 				},
 			},
 			SyncProviderArgs:    []string{"arg1", "arg2"},
@@ -74,6 +75,7 @@ func Test_FLagSourceConfiguration_Merge(t *testing.T) {
 					CertPath:   "etc/cert.ca",
 					ProviderID: "app",
 					Selector:   "source=database",
+					Interval:   5,
 				},
 			},
 			SyncProviderArgs:    []string{"arg1", "arg2"},
@@ -154,6 +156,7 @@ func Test_FLagSourceConfiguration_Merge(t *testing.T) {
 					CertPath:   "etc/cert.ca",
 					ProviderID: "app",
 					Selector:   "source=database",
+					Interval:   5,
 				},
 				{
 					Source:   "src2",


### PR DESCRIPTION
Openfeature operator does not support 'interval' for source flag type.

This PR add's the 'interval' as uint32, as per specification to the Source API definition

Once API rebuilt with new API version including the structure change, I will create PR with changes to common/flagdinjector to incorporate this change

btw, first PR here, so be gentle as I dont know the process to get things into the awesome work  you guys have done so far :) 

Signed-off-by: Martin Coetzee <martin@martincoetzee.com>