### PR TITLE
fix: Add capability to skip crd installation during helm install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ config/rendered/release.yaml
 .tar.gz
 config/manager/manager.yaml
 config/manager/kustomization.yaml
+readme-generator-for-helm
 tmpcrd.yaml
 schemas
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,8 @@ set-helm-overlay:
 	${eval KUSTOMIZE_OVERLAY = HELM}
 
 helm-package: set-helm-overlay generate release-manifests helm
+	mkdir -p chart/open-feature-operator/templates/crds
+	mv chart/open-feature-operator/templates/*customresourcedefinition* chart/open-feature-operator/templates/crds
 	$(HELM) package --version $(CHART_VERSION) chart/open-feature-operator
 	mkdir -p charts && mv open-feature-operator-*.tgz charts
 	$(HELM) repo index --url https://open-feature.github.io/open-feature-operator/charts charts

--- a/chart/open-feature-operator/.gitignore
+++ b/chart/open-feature-operator/.gitignore
@@ -1,4 +1,5 @@
 # ignore generated templates
 templates/*.yaml
+templates/crds/*.yaml
 # templates/namespace.yaml is not generated, it's a special case
 !templates/namespace.yaml

--- a/chart/open-feature-operator/README.md
+++ b/chart/open-feature-operator/README.md
@@ -137,7 +137,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `controllerManager.kubeRbacProxy.resources.requests.cpu`                  | Sets cpu resource requests for kube-rbac-proxy.          | `5m`                                         |
 | `controllerManager.kubeRbacProxy.resources.requests.memory`               | Sets memory resource requests for kube-rbac-proxy.       | `64Mi`                                       |
 | `controllerManager.manager.image.repository`                              | Sets the image for the operator.                         | `ghcr.io/open-feature/open-feature-operator` |
-| `controllerManager.manager.image.tag`                                     | Sets the version tag for the operator.                   | `v0.5.3`                                     |
+| `controllerManager.manager.image.tag`                                     | Sets the version tag for the operator.                   | `v0.5.4`                                     |
 | `controllerManager.manager.resources.limits.cpu`                          | Sets cpu resource limits for operator.                   | `500m`                                       |
 | `controllerManager.manager.resources.limits.memory`                       | Sets memory resource limits for operator.                | `128Mi`                                      |
 | `controllerManager.manager.resources.requests.cpu`                        | Sets cpu resource requests for operator.                 | `10m`                                        |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,26 +40,16 @@ If you are upgrading OFO to `v0.5.3` or lower, `flagd-proxy` (if present) won't 
 CRDs are not upgraded automatically with helm (https://helm.sh/docs/chart_best_practices/custom_resource_definitions/).
 OpenFeature Operator's CRDs are templated, and can be updated apart from the operator itself by using helm's template functionality and piping the output to `kubectl`:
 
-```console
-helm template openfeature/open-feature-operator -s templates/{CRD} | kubectl apply -f -
-```
-
-For the `featureflags.core.openfeature.dev` CRD:
+To install the CRDs:
 
 ```sh
-helm template openfeature/open-feature-operator -s templates/apiextensions.k8s.io_v1_customresourcedefinition_featureflags.core.openfeature.dev.yaml | kubectl apply -f -
-```
-
-For the `featureflagsources.core.openfeature.dev` CRD:
-
-```sh
-helm template openfeature/open-feature-operator -s templates/apiextensions.k8s.io_v1_customresourcedefinition_featureflagsources.core.openfeature.dev.yaml | kubectl apply -f -
+helm template openfeature/open-feature-operator -s "templates/crds/*.yaml" | kubectl apply -f -
 ```
 
 Keep in mind, you can set values as usual during this process:
 
-```console
-helm template openfeature/open-feature-operator -s templates/{CRD} --set defaultNamespace=myns | kubectl apply -f -
+```sh
+helm template openfeature/open-feature-operator -s "templates/crds/*.yaml" --set defaultNamespace=myns | kubectl apply -f -
 ```
 
 ### Uninstall


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- Alters the `Makefile` to move CustomResourceDefinition templates to the crds directory before packaging the helm chart.
- Alters the `.gitignore` to ignore templates in the `crds` directory.
- Updates and cleans up the CRD installation documentation.
- Enables users to optionally skip installation of the CRDs using the `--skip-crds` flag when performing `helm install`


### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #624

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

```sh
make helm-package
helm template ./chart/open-feature-operator -s "templates/crds/*.yaml" | kubectl -f -
helm install open-feature ./chart/open-feature-operator --skip-crds --create-namespace -n open-feature
```