### PR TITLE
fix: inject env variables to all pod containers

### DIFF
--- a/common/flagdinjector/flagdinjector.go
+++ b/common/flagdinjector/flagdinjector.go
@@ -72,8 +72,7 @@ func (fi *FlagdContainerInjector) InjectFlagd(
 
 	flagdContainer.Env = append(flagdContainer.Env, flagSourceConfig.ToEnvVars()...)
 	for i := 0; i < len(podSpec.Containers); i++ {
-		cntr := podSpec.Containers[i]
-		cntr.Env = append(cntr.Env, flagdContainer.Env...)
+		podSpec.Containers[i].Env = append(podSpec.Containers[i].Env, flagdContainer.Env...)
 	}
 
 	// append sync provider args

--- a/webhooks/common.go
+++ b/webhooks/common.go
@@ -1,6 +1,7 @@
 package webhooks
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -82,4 +83,12 @@ func NewFeatureFlagSourceSpec(env types.EnvConfig) *api.FeatureFlagSourceSpec {
 		OtelCollectorUri:    "",
 		ProbesEnabled:       &env.SidecarProbesEnabled,
 	}
+}
+
+func (m *PodMutator) getFeatureFlagSource(ctx context.Context, namespace string, name string) (*api.FeatureFlagSource, error) {
+	fcConfig := &api.FeatureFlagSource{}
+	if err := m.Client.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, fcConfig); err != nil {
+		return nil, err
+	}
+	return fcConfig, nil
 }

--- a/webhooks/pod_webhook_test.go
+++ b/webhooks/pod_webhook_test.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -494,7 +493,7 @@ func TestPodMutator_Handle(t *testing.T) {
 }
 
 func NewClient(withIndexes bool, objs ...client.Object) client.Client {
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme.Scheme))
+	utilruntime.Must(scheme.AddToScheme(scheme.Scheme))
 	utilruntime.Must(api.AddToScheme(scheme.Scheme))
 
 	annotationsSyncIndexer := func(obj client.Object) []string {


### PR DESCRIPTION
Part-of: #542 

## Changes

 - fixed [small issue](https://github.com/open-feature/open-feature-operator/pull/634/files#diff-edf09fdaf271cf47315a206784c3406e9a895fa16bae1ce11e5c0f4ef79d93d1R73) in flaginjector about adding env variables to all containers (not only flagd sidecar)
 - adapt flagdinjector tests to test the changed behavior + simplify them
 - polish webhook for future extension with in-process evaluation

