### PR TITLE
chore: use workspaces to make api changes easier

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Workspace Init
+        run: make workspace-init
+
       - name: Unit Test
         run: make unit-test
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -122,6 +122,7 @@ jobs:
           with:
             go-version: ${{ env.DEFAULT_GO_VERSION }}
         - run: |
+            make workspace-init
             go mod tidy
             make controller-gen
             IMG=ghcr.io/open-feature/open-feature-operator:${{ needs.release-please.outputs.release_tag_name }} make helm-package

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 
 # Copy the go source
-COPY apis/ apis/
 COPY main.go main.go
+COPY apis/ apis/
 COPY webhooks/ webhooks/
 COPY controllers/ controllers/
 COPY common/ common/

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY common/ common/
 
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN go work init ./apis && go mod download
+RUN go work init . ./apis && go mod download
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+RUN go work init ./apis && go mod download
 
 # Copy the go source
 COPY main.go main.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,16 @@ WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-COPY apis/ apis/
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go work init ./apis && go mod download
-
 # Copy the go source
+COPY apis/ apis/
 COPY main.go main.go
 COPY webhooks/ webhooks/
 COPY controllers/ controllers/
 COPY common/ common/
+
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go work init ./apis && go mod download
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,14 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
+COPY apis/ apis/
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go work init ./apis && go mod download
 
 # Copy the go source
 COPY main.go main.go
-COPY apis/ apis/
 COPY webhooks/ webhooks/
 COPY controllers/ controllers/
 COPY common/ common/

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ CHART_VERSION=v0.5.4# x-release-please-version
 ENVTEST_K8S_VERSION = 1.26.1
 WAIT_TIMEOUT_SECONDS?=60
 
+ALL_GO_MOD_DIRS := $(shell find . -type f -name 'go.mod' -exec dirname {} \; | sort)
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -256,3 +258,13 @@ install-mockgen:
 	go install github.com/golang/mock/mockgen@v1.6.0
 mockgen: install-mockgen
 	mockgen -source=controllers/common/flagd-injector.go -destination=controllers/common/mock/flagd-injector.go -package=commonmock
+
+workspace-init: workspace-clean
+	go work init
+	$(foreach module, $(ALL_GO_MOD_DIRS), go work use $(module);)
+
+workspace-update:
+	$(foreach module, $(ALL_GO_MOD_DIRS), go work use $(module);)
+
+workspace-clean:
+	rm -rf go.work


### PR DESCRIPTION
This PR introduces the use of go workspaces. Before this change, anything that involves a change or addition in the `apis` submodule required this to be split into multiple PRs (one for the api change, then a follow up to adapt the code in the controller/webhook). A similar approach is also used in https://github.com/open-feature/flagd, so I think we could also make use of that here