### PR TITLE
fix: flagd path defaults

### DIFF
--- a/apis/core/v1beta1/flagd_types.go
+++ b/apis/core/v1beta1/flagd_types.go
@@ -83,12 +83,12 @@ type IngressSpec struct {
 	// OFREPPath is the path to be used for accessing the OFREP API
 	// Default: /ofrep
 	// +optional
-	OFREPPath string `json:"ofrepPath"`
+	OFREPPath string `json:"ofrepPath,omitempty"`
 
 	// SyncPath is the path to be used for accessing the sync API
 	// Default: /flagd.sync.v1.Service
 	// +optional
-	SyncPath string `json:"syncPath"`
+	SyncPath string `json:"syncPath,omitempty"`
 }
 
 // FlagdStatus defines the observed state of Flagd

--- a/apis/core/v1beta1/flagd_types.go
+++ b/apis/core/v1beta1/flagd_types.go
@@ -76,14 +76,17 @@ type IngressSpec struct {
 	PathType networkingv1.PathType `json:"pathType,omitempty"`
 
 	// FlagdPath is the path to be used for accessing the flagd flag evaluation API
+	// Default: /flagd.evaluation.v1.Service
 	// +optional
 	FlagdPath string `json:"flagdPath,omitempty"`
 
 	// OFREPPath is the path to be used for accessing the OFREP API
+	// Default: /ofrep
 	// +optional
 	OFREPPath string `json:"ofrepPath"`
 
 	// SyncPath is the path to be used for accessing the sync API
+	// Default: /flagd.sync.v1.Service
 	// +optional
 	SyncPath string `json:"syncPath"`
 }

--- a/config/crd/bases/core.openfeature.dev_flagds.yaml
+++ b/config/crd/bases/core.openfeature.dev_flagds.yaml
@@ -56,8 +56,9 @@ spec:
                     description: Enabled enables/disables the ingress for flagd
                     type: boolean
                   flagdPath:
-                    description: FlagdPath is the path to be used for accessing the
-                      flagd flag evaluation API
+                    description: |-
+                      FlagdPath is the path to be used for accessing the flagd flag evaluation API
+                      Default: /flagd.evaluation.v1.Service
                     type: string
                   hosts:
                     description: Hosts list of hosts to be added to the ingress
@@ -69,16 +70,18 @@ spec:
                       class to be used for flagd
                     type: string
                   ofrepPath:
-                    description: OFREPPath is the path to be used for accessing the
-                      OFREP API
+                    description: |-
+                      OFREPPath is the path to be used for accessing the OFREP API
+                      Default: /ofrep
                     type: string
                   pathType:
                     description: PathType is the path type to be used for the ingress
                       rules
                     type: string
                   syncPath:
-                    description: SyncPath is the path to be used for accessing the
-                      sync API
+                    description: |-
+                      SyncPath is the path to be used for accessing the sync API
+                      Default: /flagd.sync.v1.Service
                     type: string
                   tls:
                     description: TLS configuration for the ingress

--- a/controllers/core/flagd/resources/ingress.go
+++ b/controllers/core/flagd/resources/ingress.go
@@ -6,16 +6,16 @@ import (
 
 	api "github.com/open-feature/open-feature-operator/apis/core/v1beta1"
 	"github.com/open-feature/open-feature-operator/common"
-	"github.com/open-feature/open-feature-operator/controllers/core/flagd/common"
+	resources "github.com/open-feature/open-feature-operator/controllers/core/flagd/common"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	defaultFlagdPath = "/flagd"
+	defaultFlagdPath = "/flagd.evaluation.v1.Service"
 	defaultOFREPPath = "/ofrep"
-	defaultSyncPath  = "/sync"
+	defaultSyncPath  = "/flagd.sync.v1.Service"
 )
 
 type FlagdIngress struct {

--- a/controllers/core/flagd/resources/ingress_test.go
+++ b/controllers/core/flagd/resources/ingress_test.go
@@ -71,7 +71,7 @@ func TestFlagdIngress_getIngress(t *testing.T) {
 					HTTP: &networkingv1.HTTPIngressRuleValue{
 						Paths: []networkingv1.HTTPIngressPath{
 							{
-								Path:     "/flagd",
+								Path:     "/flagd.evaluation.v1.Service",
 								PathType: &pathType,
 								Backend: networkingv1.IngressBackend{
 									Service: &networkingv1.IngressServiceBackend{
@@ -97,7 +97,7 @@ func TestFlagdIngress_getIngress(t *testing.T) {
 								},
 							},
 							{
-								Path:     "/sync",
+								Path:     "/flagd.sync.v1.Service",
 								PathType: &pathType,
 								Backend: networkingv1.IngressBackend{
 									Service: &networkingv1.IngressServiceBackend{
@@ -119,7 +119,7 @@ func TestFlagdIngress_getIngress(t *testing.T) {
 					HTTP: &networkingv1.HTTPIngressRuleValue{
 						Paths: []networkingv1.HTTPIngressPath{
 							{
-								Path:     "/flagd",
+								Path:     "/flagd.evaluation.v1.Service",
 								PathType: &pathType,
 								Backend: networkingv1.IngressBackend{
 									Service: &networkingv1.IngressServiceBackend{
@@ -145,7 +145,7 @@ func TestFlagdIngress_getIngress(t *testing.T) {
 								},
 							},
 							{
-								Path:     "/sync",
+								Path:     "/flagd.sync.v1.Service",
 								PathType: &pathType,
 								Backend: networkingv1.IngressBackend{
 									Service: &networkingv1.IngressServiceBackend{

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -942,7 +942,8 @@ Ingress
         <td><b>flagdPath</b></td>
         <td>string</td>
         <td>
-          FlagdPath is the path to be used for accessing the flagd flag evaluation API<br/>
+          FlagdPath is the path to be used for accessing the flagd flag evaluation API
+Default: /flagd.evaluation.v1.Service<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -963,7 +964,8 @@ Ingress
         <td><b>ofrepPath</b></td>
         <td>string</td>
         <td>
-          OFREPPath is the path to be used for accessing the OFREP API<br/>
+          OFREPPath is the path to be used for accessing the OFREP API
+Default: /ofrep<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -977,7 +979,8 @@ Ingress
         <td><b>syncPath</b></td>
         <td>string</td>
         <td>
-          SyncPath is the path to be used for accessing the sync API<br/>
+          SyncPath is the path to be used for accessing the sync API
+Default: /flagd.sync.v1.Service<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/test/e2e/chainsaw/flagd-with-ingress-default-paths/00-assert.yaml
+++ b/test/e2e/chainsaw/flagd-with-ingress-default-paths/00-assert.yaml
@@ -104,7 +104,7 @@ spec:
                 name: flagd-sample
                 port:
                   number: 8013
-            path: /flagd
+            path: /flagd.evaluation.v1.Service
             pathType: ImplementationSpecific
           - backend:
               service:
@@ -118,5 +118,5 @@ spec:
                 name: flagd-sample
                 port:
                   number: 8015
-            path: /sync
+            path: /flagd.sync.v1.Service
             pathType: ImplementationSpecific


### PR DESCRIPTION
The previous default paths don't work well, since flagd evaluation requests look like `.../flagd.evaluation.v1.Service/...`. These new default paths work "out of the box".

![image](https://github.com/open-feature/open-feature-operator/assets/25272906/6a70ba50-c82d-438e-979d-db30839f81cb)


