### PR TITLE
docs: require hosts, mention host-less rules

### DIFF
--- a/apis/core/v1beta1/flagd_types.go
+++ b/apis/core/v1beta1/flagd_types.go
@@ -60,9 +60,9 @@ type IngressSpec struct {
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 
-	// Hosts list of hosts to be added to the ingress
-	// +optional
-	Hosts []string `json:"hosts,omitempty"`
+	// Hosts list of hosts to be added to the ingress.
+	// Empty string corresponds to rule with no host.
+	Hosts []string `json:"hosts"`
 
 	// TLS configuration for the ingress
 	TLS []networkingv1.IngressTLS `json:"tls,omitempty"`


### PR DESCRIPTION
This can no longer be optional, we iterate over it.

Also add doc about support for an empty-host rule.

Fixes: https://github.com/open-feature/open-feature-operator/issues/656