### PR TITLE
feat: Add hostNetwork flag.

### DIFF
--- a/chart/open-feature-operator/README.md
+++ b/chart/open-feature-operator/README.md
@@ -158,22 +158,24 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Operator resource configuration
 
-| Name                                                                      | Description                                              | Value                                        |
-| ------------------------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------- |
-| `controllerManager.kubeRbacProxy.image.repository`                        | Sets the image for the kube-rbac-proxy.                  | `gcr.io/kubebuilder/kube-rbac-proxy`         |
-| `controllerManager.kubeRbacProxy.image.tag`                               | Sets the version tag for the kube-rbac-proxy.            | `v0.14.1`                                    |
-| `controllerManager.kubeRbacProxy.resources.limits.cpu`                    | Sets cpu resource limits for kube-rbac-proxy.            | `500m`                                       |
-| `controllerManager.kubeRbacProxy.resources.limits.memory`                 | Sets memory resource limits for kube-rbac-proxy.         | `128Mi`                                      |
-| `controllerManager.kubeRbacProxy.resources.requests.cpu`                  | Sets cpu resource requests for kube-rbac-proxy.          | `5m`                                         |
-| `controllerManager.kubeRbacProxy.resources.requests.memory`               | Sets memory resource requests for kube-rbac-proxy.       | `64Mi`                                       |
-| `controllerManager.manager.image.repository`                              | Sets the image for the operator.                         | `ghcr.io/open-feature/open-feature-operator` |
-| `controllerManager.manager.image.tag`                                     | Sets the version tag for the operator.                   | `v0.6.0`                                     |
-| `controllerManager.manager.resources.limits.cpu`                          | Sets cpu resource limits for operator.                   | `500m`                                       |
-| `controllerManager.manager.resources.limits.memory`                       | Sets memory resource limits for operator.                | `128Mi`                                      |
-| `controllerManager.manager.resources.requests.cpu`                        | Sets cpu resource requests for operator.                 | `10m`                                        |
-| `controllerManager.manager.resources.requests.memory`                     | Sets memory resource requests for operator.              | `64Mi`                                       |
-| `controllerManager.replicas`                                              | Sets number of replicas of the OpenFeature operator pod. | `1`                                          |
-| `managerConfig.flagsValidatonEnabled`                                     | Enables the validating webhook for FeatureFlag CR.       | `true`                                       |
-| `managerConfig.controllerManagerConfigYaml.health.healthProbeBindAddress` | Sets the bind address for health probes.                 | `:8081`                                      |
-| `managerConfig.controllerManagerConfigYaml.metrics.bindAddress`           | Sets the bind address for metrics.                       | `127.0.0.1:8080`                             |
-| `managerConfig.controllerManagerConfigYaml.webhook.port`                  | Sets the bind address for webhook.                       | `9443`                                       |
+| Name                                                                      | Description                                                                                                      | Value                                        |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `controllerManager.kubeRbacProxy.image.repository`                        | Sets the image for the kube-rbac-proxy.                                                                          | `gcr.io/kubebuilder/kube-rbac-proxy`         |
+| `controllerManager.kubeRbacProxy.image.tag`                               | Sets the version tag for the kube-rbac-proxy.                                                                    | `v0.14.1`                                    |
+| `controllerManager.kubeRbacProxy.resources.limits.cpu`                    | Sets cpu resource limits for kube-rbac-proxy.                                                                    | `500m`                                       |
+| `controllerManager.kubeRbacProxy.resources.limits.memory`                 | Sets memory resource limits for kube-rbac-proxy.                                                                 | `128Mi`                                      |
+| `controllerManager.kubeRbacProxy.resources.requests.cpu`                  | Sets cpu resource requests for kube-rbac-proxy.                                                                  | `5m`                                         |
+| `controllerManager.kubeRbacProxy.resources.requests.memory`               | Sets memory resource requests for kube-rbac-proxy.                                                               | `64Mi`                                       |
+| `controllerManager.manager.image.repository`                              | Sets the image for the operator.                                                                                 | `ghcr.io/open-feature/open-feature-operator` |
+| `controllerManager.manager.image.tag`                                     | Sets the version tag for the operator.                                                                           | `v0.6.1`                                     |
+| `controllerManager.manager.resources.limits.cpu`                          | Sets cpu resource limits for operator.                                                                           | `500m`                                       |
+| `controllerManager.manager.resources.limits.memory`                       | Sets memory resource limits for operator.                                                                        | `128Mi`                                      |
+| `controllerManager.manager.resources.requests.cpu`                        | Sets cpu resource requests for operator.                                                                         | `10m`                                        |
+| `controllerManager.manager.resources.requests.memory`                     | Sets memory resource requests for operator.                                                                      | `64Mi`                                       |
+| `controllerManager.manager.hostNetwork`                                   | Should the injector pods run on the host network (useful when using an alternate CNI in EKS)                     | `false`                                      |
+| `controllerManager.manager.dnsPolicy`                                     | Pod DNS resolution scheme. Should be `ClusterFirstWithHostNet` if hostNetwork is true, `ClusterFirst` otherwise. | `ClusterFirst`                               |
+| `controllerManager.replicas`                                              | Sets number of replicas of the OpenFeature operator pod.                                                         | `1`                                          |
+| `managerConfig.flagsValidatonEnabled`                                     | Enables the validating webhook for FeatureFlag CR.                                                               | `true`                                       |
+| `managerConfig.controllerManagerConfigYaml.health.healthProbeBindAddress` | Sets the bind address for health probes.                                                                         | `:8081`                                      |
+| `managerConfig.controllerManagerConfigYaml.metrics.bindAddress`           | Sets the bind address for metrics.                                                                               | `127.0.0.1:8080`                             |
+| `managerConfig.controllerManagerConfigYaml.webhook.port`                  | Sets the bind address for webhook.                                                                               | `9443`                                       |

--- a/chart/open-feature-operator/values.yaml
+++ b/chart/open-feature-operator/values.yaml
@@ -137,6 +137,10 @@ controllerManager:
         cpu: 10m
         ## @param controllerManager.manager.resources.requests.memory Sets memory resource requests for operator.
         memory: 64Mi
+    ## @param controllerManager.manager.hostNetwork Should the injector pods run on the host network (useful when using an alternate CNI in EKS)
+    hostNetwork: false
+    ## @param controllerManager.manager.dnsPolicy Pod DNS resolution scheme. Should be `ClusterFirstWithHostNet` if hostNetwork is true, `ClusterFirst` otherwise.
+    dnsPolicy: ClusterFirst
   ## @param controllerManager.replicas Sets number of replicas of the OpenFeature operator pod.
   replicas: 1
 

--- a/config/overlays/helm/manager.yaml
+++ b/config/overlays/helm/manager.yaml
@@ -9,6 +9,9 @@ spec:
     spec:
       # this is transformed by .github/scripts/strip-kustomize-helm.sh
       ___imagePullSecrets___: "___ ___newline___{{ toYaml .Values.imagePullSecrets | indent 8 }}___"
+      dnsPolicy: "{{ .Values.controllerManager.manager.dnsPolicy }}"
+      # this is transformed by .github/scripts/strip-kustomize-helm.sh
+      hostNetwork: "___{{ .Values.controllerManager.manager.hostNetwork }}___"
       containers:
         - name: manager
           image: "{{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag }}"
@@ -20,72 +23,72 @@ spec:
               cpu: "{{ .Values.controllerManager.manager.resources.requests.cpu }}"
               memory: "{{ .Values.controllerManager.manager.resources.requests.memory }}"
           env:
-          - name: SIDECAR_MANAGEMENT_PORT
-            value: "{{ .Values.sidecarConfiguration.managementPort }}"
-          - name: SIDECAR_PORT
-            value: "{{ .Values.sidecarConfiguration.port }}"
-          - name: SIDECAR_SOCKET_PATH
-            value: "{{ .Values.sidecarConfiguration.socketPath }}"
-          - name: SIDECAR_IMAGE
-            value: "{{ .Values.sidecarConfiguration.image.repository }}"
-          - name: SIDECAR_TAG
-            value: "{{ .Values.sidecarConfiguration.image.tag }}"
-          - name: SIDECAR_PROVIDER_ARGS
-            value: "{{ .Values.sidecarConfiguration.providerArgs }}"
-          - name: SIDECAR_ENV_VAR_PREFIX
-            value: "{{ .Values.sidecarConfiguration.envVarPrefix }}"
-          - name: SIDECAR_SYNC_PROVIDER
-            value: "{{ .Values.sidecarConfiguration.defaultSyncProvider }}"
-          - name: SIDECAR_EVALUATOR
-            value: "{{ .Values.sidecarConfiguration.evaluator }}"
-          - name: SIDECAR_LOG_FORMAT
-            value: "{{ .Values.sidecarConfiguration.logFormat }}"
-          - name: SIDECAR_PROBES_ENABLED
-            value: "{{ .Values.sidecarConfiguration.probesEnabled }}"
-          - name: FLAGD_PROXY_IMAGE
-            value: "{{ .Values.flagdProxyConfiguration.image.repository }}"
-          - name: FLAGD_PROXY_TAG
-            value: "{{ .Values.flagdProxyConfiguration.image.tag }}"
-          - name: FLAGD_PROXY_PORT
-            value: "{{ .Values.flagdProxyConfiguration.port }}"
-          - name: FLAGD_PROXY_MANAGEMENT_PORT
-            value: "{{ .Values.flagdProxyConfiguration.managementPort }}"
-          - name: FLAGD_PROXY_DEBUG_LOGGING
-            value: "{{ .Values.flagdProxyConfiguration.debugLogging }}"
-          - name: FLAGD_IMAGE
-            value: "{{ .Values.flagdConfiguration.image.repository }}"
-          - name: FLAGD_TAG
-            value: "{{ .Values.flagdConfiguration.image.tag }}"
-          - name: FLAGD_PORT
-            value: "{{ .Values.flagdConfiguration.port }}"
-          - name: FLAGD_OFREP_PORT
-            value: "{{ .Values.flagdConfiguration.ofrepPort }}"
-          - name: FLAGD_SYNC_PORT
-            value: "{{ .Values.flagdConfiguration.syncPort }}"
-          - name: FLAGD_MANAGEMENT_PORT
-            value: "{{ .Values.flagdConfiguration.managementPort }}"
-          - name: FLAGD_DEBUG_LOGGING
-            value: "{{ .Values.flagdConfiguration.debugLogging }}"
-          - name: FLAGS_VALIDATION_ENABLED
-            value: "{{ .Values.managerConfig.flagsValidatonEnabled }}"
-          - name: IN_PROCESS_PORT
-            value: "{{ .Values.inProcessConfiguration.port }}"
-          - name: IN_PROCESS_HOST
-            value: "{{ .Values.inProcessConfiguration.host }}"
-          - name: IN_PROCESS_SOCKET_PATH
-            value: "{{ .Values.inProcessConfiguration.socketPath }}"
-          - name: IN_PROCESS_TLS
-            value: "{{ .Values.inProcessConfiguration.tls }}"
-          - name: IN_PROCESS_OFFLINE_FLAG_SOURCE_PATH
-            value: "{{ .Values.inProcessConfiguration.offlineFlagSourcePath }}"
-          - name: IN_PROCESS_SELECTOR
-            value: "{{ .Values.inProcessConfiguration.selector }}"
-          - name: IN_PROCESS_CACHE
-            value: "{{ .Values.inProcessConfiguration.cache.type }}"
-          - name: IN_PROCESS_ENV_VAR_PREFIX
-            value: "{{ .Values.inProcessConfiguration.envVarPrefix }}"
-          - name: IN_PROCESS_CACHE_MAX_SIZE
-            value: "{{ .Values.inProcessConfiguration.cache.size }}"
+            - name: SIDECAR_MANAGEMENT_PORT
+              value: "{{ .Values.sidecarConfiguration.managementPort }}"
+            - name: SIDECAR_PORT
+              value: "{{ .Values.sidecarConfiguration.port }}"
+            - name: SIDECAR_SOCKET_PATH
+              value: "{{ .Values.sidecarConfiguration.socketPath }}"
+            - name: SIDECAR_IMAGE
+              value: "{{ .Values.sidecarConfiguration.image.repository }}"
+            - name: SIDECAR_TAG
+              value: "{{ .Values.sidecarConfiguration.image.tag }}"
+            - name: SIDECAR_PROVIDER_ARGS
+              value: "{{ .Values.sidecarConfiguration.providerArgs }}"
+            - name: SIDECAR_ENV_VAR_PREFIX
+              value: "{{ .Values.sidecarConfiguration.envVarPrefix }}"
+            - name: SIDECAR_SYNC_PROVIDER
+              value: "{{ .Values.sidecarConfiguration.defaultSyncProvider }}"
+            - name: SIDECAR_EVALUATOR
+              value: "{{ .Values.sidecarConfiguration.evaluator }}"
+            - name: SIDECAR_LOG_FORMAT
+              value: "{{ .Values.sidecarConfiguration.logFormat }}"
+            - name: SIDECAR_PROBES_ENABLED
+              value: "{{ .Values.sidecarConfiguration.probesEnabled }}"
+            - name: FLAGD_PROXY_IMAGE
+              value: "{{ .Values.flagdProxyConfiguration.image.repository }}"
+            - name: FLAGD_PROXY_TAG
+              value: "{{ .Values.flagdProxyConfiguration.image.tag }}"
+            - name: FLAGD_PROXY_PORT
+              value: "{{ .Values.flagdProxyConfiguration.port }}"
+            - name: FLAGD_PROXY_MANAGEMENT_PORT
+              value: "{{ .Values.flagdProxyConfiguration.managementPort }}"
+            - name: FLAGD_PROXY_DEBUG_LOGGING
+              value: "{{ .Values.flagdProxyConfiguration.debugLogging }}"
+            - name: FLAGD_IMAGE
+              value: "{{ .Values.flagdConfiguration.image.repository }}"
+            - name: FLAGD_TAG
+              value: "{{ .Values.flagdConfiguration.image.tag }}"
+            - name: FLAGD_PORT
+              value: "{{ .Values.flagdConfiguration.port }}"
+            - name: FLAGD_OFREP_PORT
+              value: "{{ .Values.flagdConfiguration.ofrepPort }}"
+            - name: FLAGD_SYNC_PORT
+              value: "{{ .Values.flagdConfiguration.syncPort }}"
+            - name: FLAGD_MANAGEMENT_PORT
+              value: "{{ .Values.flagdConfiguration.managementPort }}"
+            - name: FLAGD_DEBUG_LOGGING
+              value: "{{ .Values.flagdConfiguration.debugLogging }}"
+            - name: FLAGS_VALIDATION_ENABLED
+              value: "{{ .Values.managerConfig.flagsValidatonEnabled }}"
+            - name: IN_PROCESS_PORT
+              value: "{{ .Values.inProcessConfiguration.port }}"
+            - name: IN_PROCESS_HOST
+              value: "{{ .Values.inProcessConfiguration.host }}"
+            - name: IN_PROCESS_SOCKET_PATH
+              value: "{{ .Values.inProcessConfiguration.socketPath }}"
+            - name: IN_PROCESS_TLS
+              value: "{{ .Values.inProcessConfiguration.tls }}"
+            - name: IN_PROCESS_OFFLINE_FLAG_SOURCE_PATH
+              value: "{{ .Values.inProcessConfiguration.offlineFlagSourcePath }}"
+            - name: IN_PROCESS_SELECTOR
+              value: "{{ .Values.inProcessConfiguration.selector }}"
+            - name: IN_PROCESS_CACHE
+              value: "{{ .Values.inProcessConfiguration.cache.type }}"
+            - name: IN_PROCESS_ENV_VAR_PREFIX
+              value: "{{ .Values.inProcessConfiguration.envVarPrefix }}"
+            - name: IN_PROCESS_CACHE_MAX_SIZE
+              value: "{{ .Values.inProcessConfiguration.cache.size }}"
           args:
             - --leader-elect
             - --sidecar-cpu-limit={{ .Values.sidecarConfiguration.resources.limits.cpu }}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Add `hostNetwork` and `dnsPolicy` settings to enable compatibility with EKS clusters that have a custom CNI. Without these, the MutatingWebhook that adds the flagd sidecar to pods will not function.

### Related Issues
- This provided inspiration for this fix: https://github.com/elastic/cloud-on-k8s/issues/1369
- Another issue with the same problem/fix: https://stackoverflow.com/questions/59801157/aws-eks-k8s-cluster-with-weave-cni-plugin-cannot-have-custom-metrics
- The HashiCorp vault sidecar injector explicitly notes this in its Helm chart values as well: https://github.com/hashicorp/vault-helm/blob/834cd7f85a48179bef83ce48f82aec2128bc6020/values.yaml#L328

### Notes
This relies on `.github/scripts/strip-kustomize-helm.sh` because boolean values have to be true/false without quotes, so to set `hostNetwork` to true in the helm chart, we have to strip out the quotes that are used to allow kustomize to ignore helm chart directives.

### Follow-up Tasks
- The ongoing issues related to the kustomize build process and the conflict with Helm continue to plague this type of system.

### How to test
Test the operator with a test workload that uses the flagd sidecar on an EKS cluster with a custom CNI (Calico is most common).
