### PR TITLE
Added Support for custom labels and annotations in pods created by chart

### DIFF
--- a/chart/open-feature-operator/values.yaml
+++ b/chart/open-feature-operator/values.yaml
@@ -120,6 +120,10 @@ controllerManager:
         cpu: 5m
         ## @param controllerManager.kubeRbacProxy.resources.requests.memory Sets memory resource requests for kube-rbac-proxy.
         memory: 64Mi
+    customLabels:
+      app: kube-rbac-proxy
+    customAnnotations:
+      note: "Custom annotation for kube-rbac-proxy"
   manager:
     image:
       ## @param controllerManager.manager.image.repository Sets the image for the operator.
@@ -139,6 +143,10 @@ controllerManager:
         memory: 64Mi
   ## @param controllerManager.replicas Sets number of replicas of the OpenFeature operator pod.
   replicas: 1
+  customLabels:
+    app: controller-manager
+  customAnnotations:
+    note: "Custom annotation for controller-manager"
 
 managerConfig:
   ## @param managerConfig.flagsValidatonEnabled Enables the validating webhook for FeatureFlag CR.

--- a/config/overlays/helm/manager.yaml
+++ b/config/overlays/helm/manager.yaml
@@ -3,9 +3,28 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
+  labels:
+    app: controller-manager
+    {{- if .Values.customLabels }}
+    {{ toYaml .Values.customLabels | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.customAnnotations }}
+    {{ toYaml .Values.customAnnotations | nindent 4 }}
+    {{- end }}  
 spec:
   replicas: 0{{ .Values.controllerManager.replicas }}
   template:
+  metadata:
+      labels:
+        app: controller-manager
+        {{- if .Values.customLabels }}
+        {{ toYaml .Values.customLabels | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- if .Values.customAnnotations }}
+        {{ toYaml .Values.customAnnotations | nindent 8 }}
+        {{- end }} 
     spec:
       # this is transformed by .github/scripts/strip-kustomize-helm.sh
       ___imagePullSecrets___: "___ ___newline___{{ toYaml .Values.imagePullSecrets | indent 8 }}___"


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This PR introduces support for custom labels and annotations for Kubernetes resources controllerManager and kubeRbacProxy to enhance organization and metadata management within the cluster.



### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #677 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

