### PR TITLE
fix: remove duplicated port in helm

### DIFF
--- a/config/overlays/helm/exclude-webhook-server-container-port.yaml
+++ b/config/overlays/helm/exclude-webhook-server-container-port.yaml
@@ -1,0 +1,17 @@
+# delete the default webhook-server port (to avoid duplicate) since we build it from helm
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+          $patch: delete
+          

--- a/config/overlays/helm/exclude-webhook-server-container-port.yaml
+++ b/config/overlays/helm/exclude-webhook-server-container-port.yaml
@@ -14,4 +14,3 @@ spec:
           name: webhook-server
           protocol: TCP
           $patch: delete
-          

--- a/config/overlays/helm/kustomization.yaml
+++ b/config/overlays/helm/kustomization.yaml
@@ -14,6 +14,7 @@ namespace: |-
 patchesStrategicMerge:
   - exclude-ns.yaml
   - manager.yaml
+  - exclude-webhook-server-container-port.yaml
   - exclude-validatingwebhook.yaml
 
 configMapGenerator:


### PR DESCRIPTION
Delete the default webhook-server port (to avoid duplicate) since we build it from helm