### PR TITLE
fix: Fix Kustomize installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,12 +214,11 @@ KUSTOMIZE_VERSION ?= v5.4.1
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
 CRDOC_VERSION ?= v0.6.2
 
-KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
 	[ -e "$(KUSTOMIZE)" ] && rm -rf "$(KUSTOMIZE)" || true
-	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
+	test -s ${LOCALBIN}/kustomize || GOBIN=${LOCALBIN} GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VERSION)
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.


### PR DESCRIPTION
## This PR
- When running `make helm-package` the install script for Kustomize is broken https://github.com/kubernetes-sigs/kustomize/issues/5562
- Add the recommended fix.

### Related Issues
- https://github.com/kubernetes-sigs/kustomize/issues/5562

### Follow-up Tasks
We should investigate if the install script is truly dead and unsupported now, or if, instead of this fix, we should instead push for the installation script to be repaired.

### How to test
1. Delete `./bin` (`rm -rf ./bin`) from local clone of open-feature-operator
2. Run `make helm-package`
3. Note error:
`Version v5.4.1 does not exist or is not available for linux/amd64.`
4. Apply this patch
5. Re-run `make helm-package`
6. Note error is now gone.