### PR TITLE
fix: Add missing poddisruption budget permissions in manager cluster role

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -147,3 +147,11 @@ rules:
   verbs:
   - get
   - update
+- apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+  verbs:
+    - list
+    - create
+    - watch


### PR DESCRIPTION
## This PR
Add missing poddisruption budget permissions in manager cluster role

Open feature operator now attempts to list, create, and watch pod disruption budget resources for flagd proxy since it can now configure HA replica for flagd proxy

### Related Issues
Fixes #717 
Related to #712 

### Notes
* update existing ClusterRole configuration to include poddisruptionbudget resource permissions for api group: policy


### How to test
* manually apply changes to ClusterRole resource, change FlagSource and watch for permission errors. Retry with extra verbs until no reconcile errors were encountered.


