### PR TITLE
ci(trivy): fetch vulnerabilities DB from ERC

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -83,6 +83,7 @@ jobs:
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"
         env:
+          # use an alternative trivvy db to avoid rate limits
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -82,6 +82,8 @@ jobs:
           template: "@/contrib/sarif.tpl"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -78,8 +78,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.28.0
         with:
           input: ${{ github.workspace }}/open-feature-operator-local.tar
-          format: "template"
-          template: "@/contrib/sarif.tpl"
+          format: "sarif"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"
         env:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -75,7 +75,7 @@ jobs:
           cache-from: type=gha,scope=${{ github.ref_name }}-ofo
           cache-to: type=gha,scope=${{ github.ref_name }}-ofo
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.27.0
+        uses: aquasecurity/trivy-action@0.56.2
         with:
           input: ${{ github.workspace }}/open-feature-operator-local.tar
           format: "template"
@@ -83,7 +83,7 @@ jobs:
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"
         env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -75,7 +75,7 @@ jobs:
           cache-from: type=gha,scope=${{ github.ref_name }}-ofo
           cache-to: type=gha,scope=${{ github.ref_name }}-ofo
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.56.2
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           input: ${{ github.workspace }}/open-feature-operator-local.tar
           format: "template"


### PR DESCRIPTION
We're running into GHCR throttling issues. Switching to ECR should resolve this issue.

https://github.com/aquasecurity/trivy-action/issues/389#issuecomment-2373539982
