### PR TITLE
fix: Add missing poddisruptionbudget update verb

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -155,3 +155,4 @@ rules:
     - list
     - create
     - watch
+    - update

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -20,7 +20,9 @@ The definition of this role can be found [here](../config/rbac//leader_election_
 ### Manager Role
 
 The `manager-role` applies the rules described below, its definition can be found [here](../config/rbac/role.yaml).
-It provides the operator with sufficient permissions over the `core.openfeature.dev` resources, and the required permissions for injecting the `flagd` sidecar into appropriate pods. 
+It provides the operator with sufficient permissions over the `core.openfeature.dev` resources, 
+the required permissions for injecting the `flagd` sidecar into appropriate pods, 
+and managing flagd-proxy resources
 The `ConfigMap` permissions are needed to allow the mounting of `FeatureFlag` resources for file syncs.
 
 | API Group                   | Resource                        | Verbs                                           |
@@ -29,6 +31,7 @@ The `ConfigMap` permissions are needed to allow the mounting of `FeatureFlag` re
 | -                           | `Pod`                           | create, delete, get, list, patch, update, watch |
 | -                           | `ServiceAccount`                | get, list, watch                                |
 | -                           | `Service` *(\*)*                | create, delete, get, list, patch, update, watch |
+| `policy`                    | `PodDisruptionBudget`           | create, list, update, watch                     |
 | `networking.k8s.io`         | `Ingress` *(\*)*                | create, delete, get, list, patch, update, watch |
 | `core.openfeature.dev`      | `FeatureFlag`                   | create, delete, get, list, patch, update, watch |
 | `core.openfeature.dev`      | `FeatureFlag Finalizers`        | update                                          |


### PR DESCRIPTION
## This PR
Openfeature operator controller manager needs to be able to update pod disruption budgets as replica counts can be updated

* add update verb to manager role for pod disruption budgets

### Related Issues
#717

### Notes
After deploying v0.8.1 I noticed these new permissions were not in the role. I think I've missed some required change to get these reconciled in to the role resource.

### Follow-up Tasks
* double check that this get's reconciled to role when updating versions / installing through helm.

### How to test
- Install via helm to a cluster 
- include flagdProxyConfiguration.replicaCount=2 in helm configuration in values
- add a flagd-proxy FlagSourceConfiguration
- watch openfeature operator controller manager logs, validate PodDisruptionBudget gets updated to have max 2 pods

