### PR TITLE
fix: end-to-end.yaml

### DIFF
--- a/config/samples/end-to-end.yaml
+++ b/config/samples/end-to-end.yaml
@@ -8,6 +8,7 @@ apiVersion: core.openfeature.dev/v1beta1
 kind: FeatureFlag
 metadata:
   name: featureflag-sample
+  namespace: open-feature-demo
 spec:
   flagSpec:
     flags:
@@ -25,7 +26,7 @@ metadata:
   namespace: open-feature-demo
 spec:
   sources:
-  - source: open-feature-demo/end-to-end
+  - source: open-feature-demo/featureflag-sample
     provider: kubernetes
 ---
 # Deployment of a demo-app using our custom resource


### PR DESCRIPTION
Added missing namespace fixed invalid reference to FeatureFlag in FeatureFlagSource.

## This PR

Fixes bugs in the sample end-to-end K8S manifest

### Related Issues

N/A

### Notes

N/A

### Follow-up Tasks

N/A

### How to test

`kubectl apply -f end-to-end.yaml` now results in successful deployment. 
