### PR TITLE
feat: add configurable cluster domain support

### DIFF
--- a/internal/common/flagdinjector/flagdinjector.go
+++ b/internal/common/flagdinjector/flagdinjector.go
@@ -350,7 +350,7 @@ func (fi *FlagdContainerInjector) toFlagdProxyConfig(ctx context.Context, object
 	return types.SourceConfig{
 		Provider: "grpc",
 		Selector: fmt.Sprintf("core.openfeature.dev/%s/%s", ns, n),
-		URI:      fmt.Sprintf("%s.%s.svc.cluster.local:%d", flagdproxy.FlagdProxyServiceName, fi.FlagdProxyConfig.Namespace, fi.FlagdProxyConfig.Port),
+		URI:      fmt.Sprintf("%s.%s.svc.%s:%d", flagdproxy.FlagdProxyServiceName, fi.FlagdProxyConfig.Namespace, fi.FlagdProxyConfig.ClusterDomain, fi.FlagdProxyConfig.Port),
 	}, nil
 }
 

--- a/internal/common/flagdinjector/flagdinjector_test.go
+++ b/internal/common/flagdinjector/flagdinjector_test.go
@@ -951,6 +951,7 @@ func getProxyConfig() *flagdproxy.FlagdProxyConfiguration {
 		Image:          testImage,
 		Tag:            testTag,
 		Namespace:      "my-namespace",
+		ClusterDomain:  "cluster.local",
 	}
 }
 

--- a/internal/common/flagdproxy/flagdproxy.go
+++ b/internal/common/flagdproxy/flagdproxy.go
@@ -46,6 +46,7 @@ type FlagdProxyConfiguration struct {
 	ImagePullSecrets       []string
 	Labels                 map[string]string
 	Annotations            map[string]string
+	ClusterDomain          string
 }
 
 func NewFlagdProxyConfiguration(env types.EnvConfig, imagePullSecrets []string, labels map[string]string, annotations map[string]string) *FlagdProxyConfiguration {
@@ -61,6 +62,7 @@ func NewFlagdProxyConfiguration(env types.EnvConfig, imagePullSecrets []string, 
 		ImagePullSecrets:       imagePullSecrets,
 		Labels:                 labels,
 		Annotations:            annotations,
+		ClusterDomain:          env.ClusterDomain,
 	}
 }
 

--- a/internal/common/flagdproxy/flagdproxy_test.go
+++ b/internal/common/flagdproxy/flagdproxy_test.go
@@ -205,6 +205,7 @@ func TestNewFlagdProxyConfiguration(t *testing.T) {
 		FlagdProxyPort:           8015,
 		FlagdProxyManagementPort: 8016,
 		FlagdProxyReplicaCount:   123,
+		ClusterDomain:            "cluster.local",
 	}, pullSecrets, labels, annotations)
 
 	require.NotNil(t, kpConfig)
@@ -217,6 +218,7 @@ func TestNewFlagdProxyConfiguration(t *testing.T) {
 		Replicas:               123,
 		Labels:                 labels,
 		Annotations:            annotations,
+		ClusterDomain:          "cluster.local",
 	}, kpConfig)
 }
 

--- a/internal/common/types/envconfig.go
+++ b/internal/common/types/envconfig.go
@@ -10,6 +10,7 @@ type EnvConfig struct {
 	FlagdProxyPort           int    `envconfig:"FLAGD_PROXY_PORT" default:"8015"`
 	FlagdProxyManagementPort int    `envconfig:"FLAGD_PROXY_MANAGEMENT_PORT" default:"8016"`
 	FlagdProxyDebugLogging   bool   `envconfig:"FLAGD_PROXY_DEBUG_LOGGING" default:"false"`
+	ClusterDomain            string `envconfig:"CLUSTER_DOMAIN" default:"cluster.local"`
 
 	FlagdImage string `envconfig:"FLAGD_IMAGE" default:"ghcr.io/open-feature/flagd"`
 	// renovate: datasource=github-tags depName=open-feature/flagd/flagd


### PR DESCRIPTION
Add CLUSTER_DOMAIN environment variable to allow customization of the Kubernetes cluster domain used in flagd-proxy service URIs. The default value remains "cluster.local" to maintain backward compatibility.

This enables support for clusters using non-standard domain configurations.

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds this new feature

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #764

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

