### PR TITLE
fix: Set appProtocol for service resources

### DIFF
--- a/internal/common/flagdproxy/flagdproxy.go
+++ b/internal/common/flagdproxy/flagdproxy.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -179,9 +180,10 @@ func (f *FlagdProxyHandler) newFlagdProxyService(ownerReference *metav1.OwnerRef
 			},
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "flagd-proxy",
-					Port:       int32(f.config.Port),
-					TargetPort: intstr.FromInt(f.config.Port),
+					AppProtocol: ptr.To("grpc"),
+					Name:        "flagd-proxy",
+					Port:        int32(f.config.Port),
+					TargetPort:  intstr.FromInt(f.config.Port),
 				},
 			},
 		},

--- a/internal/common/flagdproxy/flagdproxy_test.go
+++ b/internal/common/flagdproxy/flagdproxy_test.go
@@ -158,9 +158,10 @@ var (
 			},
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "flagd-proxy",
-					Port:       int32(testPort),
-					TargetPort: intstr.FromInt(testPort),
+					AppProtocol: ptr.To("grpc"),
+					Name:        "flagd-proxy",
+					Port:        int32(testPort),
+					TargetPort:  intstr.FromInt(testPort),
 				},
 			},
 		},

--- a/internal/controller/core/flagd/resources/service.go
+++ b/internal/controller/core/flagd/resources/service.go
@@ -13,6 +13,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var (
+	grpcAppProtocol = "grpc"
+	httpAppProtocol = "http"
+)
+
 type FlagdService struct {
 	FlagdConfig resources.FlagdConfiguration
 }
@@ -56,29 +61,33 @@ func (r FlagdService) GetResource(_ context.Context, flagd *api.Flagd) (client.O
 			},
 			Ports: []v1.ServicePort{
 				{
-					Name: "flagd",
-					Port: int32(r.FlagdConfig.FlagdPort),
+					AppProtocol: &grpcAppProtocol,
+					Name:        "flagd",
+					Port:        int32(r.FlagdConfig.FlagdPort),
 					TargetPort: intstr.IntOrString{
 						IntVal: int32(r.FlagdConfig.FlagdPort),
 					},
 				},
 				{
-					Name: "ofrep",
-					Port: int32(r.FlagdConfig.OFREPPort),
+					AppProtocol: &httpAppProtocol,
+					Name:        "ofrep",
+					Port:        int32(r.FlagdConfig.OFREPPort),
 					TargetPort: intstr.IntOrString{
 						IntVal: int32(r.FlagdConfig.OFREPPort),
 					},
 				},
 				{
-					Name: "sync",
-					Port: int32(r.FlagdConfig.SyncPort),
+					AppProtocol: &grpcAppProtocol,
+					Name:        "sync",
+					Port:        int32(r.FlagdConfig.SyncPort),
 					TargetPort: intstr.IntOrString{
 						IntVal: int32(r.FlagdConfig.SyncPort),
 					},
 				},
 				{
-					Name: "metrics",
-					Port: int32(r.FlagdConfig.ManagementPort),
+					AppProtocol: &httpAppProtocol,
+					Name:        "metrics",
+					Port:        int32(r.FlagdConfig.ManagementPort),
 					TargetPort: intstr.IntOrString{
 						IntVal: int32(r.FlagdConfig.ManagementPort),
 					},

--- a/internal/controller/core/flagd/resources/service.go
+++ b/internal/controller/core/flagd/resources/service.go
@@ -10,12 +10,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-var (
-	grpcAppProtocol = "grpc"
-	httpAppProtocol = "http"
 )
 
 type FlagdService struct {
@@ -61,7 +57,7 @@ func (r FlagdService) GetResource(_ context.Context, flagd *api.Flagd) (client.O
 			},
 			Ports: []v1.ServicePort{
 				{
-					AppProtocol: &grpcAppProtocol,
+					AppProtocol: ptr.To("grpc"),
 					Name:        "flagd",
 					Port:        int32(r.FlagdConfig.FlagdPort),
 					TargetPort: intstr.IntOrString{
@@ -69,7 +65,7 @@ func (r FlagdService) GetResource(_ context.Context, flagd *api.Flagd) (client.O
 					},
 				},
 				{
-					AppProtocol: &httpAppProtocol,
+					AppProtocol: ptr.To("http"),
 					Name:        "ofrep",
 					Port:        int32(r.FlagdConfig.OFREPPort),
 					TargetPort: intstr.IntOrString{
@@ -77,7 +73,7 @@ func (r FlagdService) GetResource(_ context.Context, flagd *api.Flagd) (client.O
 					},
 				},
 				{
-					AppProtocol: &grpcAppProtocol,
+					AppProtocol: ptr.To("grpc"),
 					Name:        "sync",
 					Port:        int32(r.FlagdConfig.SyncPort),
 					TargetPort: intstr.IntOrString{
@@ -85,7 +81,7 @@ func (r FlagdService) GetResource(_ context.Context, flagd *api.Flagd) (client.O
 					},
 				},
 				{
-					AppProtocol: &httpAppProtocol,
+					AppProtocol: ptr.To("http"),
 					Name:        "metrics",
 					Port:        int32(r.FlagdConfig.ManagementPort),
 					TargetPort: intstr.IntOrString{

--- a/internal/controller/core/flagd/resources/service_test.go
+++ b/internal/controller/core/flagd/resources/service_test.go
@@ -36,10 +36,10 @@ func TestFlagdService_getService(t *testing.T) {
 		appProtocol string
 		port        int32
 	}{
-		"flagd":   {grpcAppProtocol, 8013},
-		"ofrep":   {httpAppProtocol, 8016},
-		"sync":    {grpcAppProtocol, 8015},
-		"metrics": {httpAppProtocol, 8014},
+		"flagd":   {"grpc", 8013},
+		"ofrep":   {"http", 8016},
+		"sync":    {"grpc", 8015},
+		"metrics": {"http", 8014},
 	}
 
 	ports := svc.(*v1.Service).Spec.Ports

--- a/internal/controller/core/flagd/resources/service_test.go
+++ b/internal/controller/core/flagd/resources/service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,6 +31,27 @@ func TestFlagdService_getService(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, svc)
 	require.IsType(t, &v1.Service{}, svc)
+
+	expectedPorts := map[string]struct {
+		appProtocol string
+		port        int32
+	}{
+		"flagd":   {grpcAppProtocol, 8013},
+		"ofrep":   {httpAppProtocol, 8016},
+		"sync":    {grpcAppProtocol, 8015},
+		"metrics": {httpAppProtocol, 8014},
+	}
+
+	ports := svc.(*v1.Service).Spec.Ports
+	require.Len(t, ports, len(expectedPorts), "unexpected number of ports")
+
+	for _, port := range ports {
+		expected, ok := expectedPorts[port.Name]
+		require.True(t, ok, "unexpected port: %s", port.Name)
+		require.Equal(t, expected.appProtocol, *port.AppProtocol)
+		require.Equal(t, expected.port, port.Port)
+		require.Equal(t, intstr.FromInt(int(expected.port)), port.TargetPort)
+	}
 }
 
 func Test_areServicesEqual(t *testing.T) {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds the `appProtocol` in the service resource for all the exposed ports

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

- #796 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

