### PR TITLE
feat: add valueFrom field handling in envVars for FeatureFlagSource and InProcessConfiguration

### DIFF
--- a/api/core/v1beta1/featureflagsource_types.go
+++ b/api/core/v1beta1/featureflagsource_types.go
@@ -221,10 +221,17 @@ func (fc *FeatureFlagSourceSpec) ToEnvVars() []corev1.EnvVar {
 	envs := []corev1.EnvVar{}
 
 	for _, envVar := range fc.EnvVars {
-		envs = append(envs, corev1.EnvVar{
-			Name:  fc.decorateEnvVarName(envVar.Name),
-			Value: envVar.Value,
-		})
+	    newEnvVar := corev1.EnvVar{
+            Name: fc.decorateEnvVarName(envVar.Name),
+        }
+
+        if envVar.Value != "" {
+            newEnvVar.Value = envVar.Value
+        } else if envVar.ValueFrom != nil {
+            newEnvVar.ValueFrom = envVar.ValueFrom
+        }
+
+        envs = append(envs, newEnvVar)
 	}
 
 	// default values are always included in the envVars

--- a/api/core/v1beta1/featureflagsource_types.go
+++ b/api/core/v1beta1/featureflagsource_types.go
@@ -281,10 +281,17 @@ func (fc *FeatureFlagSourceSpec) ToEnvVars() []corev1.EnvVar {
 	envs := []corev1.EnvVar{}
 
 	for _, envVar := range fc.EnvVars {
-		envs = append(envs, corev1.EnvVar{
-			Name:  fc.decorateEnvVarName(envVar.Name),
-			Value: envVar.Value,
-		})
+	    newEnvVar := corev1.EnvVar{
+            Name: fc.decorateEnvVarName(envVar.Name),
+        }
+
+        if envVar.Value != "" {
+            newEnvVar.Value = envVar.Value
+        } else if envVar.ValueFrom != nil {
+            newEnvVar.ValueFrom = envVar.ValueFrom
+        }
+
+        envs = append(envs, newEnvVar)
 	}
 
 	// default values are always included in the envVars

--- a/api/core/v1beta1/featureflagsource_types.go
+++ b/api/core/v1beta1/featureflagsource_types.go
@@ -281,17 +281,17 @@ func (fc *FeatureFlagSourceSpec) ToEnvVars() []corev1.EnvVar {
 	envs := []corev1.EnvVar{}
 
 	for _, envVar := range fc.EnvVars {
-	    newEnvVar := corev1.EnvVar{
-            Name: fc.decorateEnvVarName(envVar.Name),
-        }
+		newEnvVar := corev1.EnvVar{
+			Name: fc.decorateEnvVarName(envVar.Name),
+		}
 
-        if envVar.Value != "" {
-            newEnvVar.Value = envVar.Value
-        } else if envVar.ValueFrom != nil {
-            newEnvVar.ValueFrom = envVar.ValueFrom
-        }
+		if envVar.Value != "" {
+			newEnvVar.Value = envVar.Value
+		} else if envVar.ValueFrom != nil {
+			newEnvVar.ValueFrom = envVar.ValueFrom
+		}
 
-        envs = append(envs, newEnvVar)
+		envs = append(envs, newEnvVar)
 	}
 
 	// default values are always included in the envVars

--- a/api/core/v1beta1/featureflagsource_types_test.go
+++ b/api/core/v1beta1/featureflagsource_types_test.go
@@ -180,6 +180,43 @@ func Test_FLagSourceConfiguration_ToEnvVars(t *testing.T) {
 					Name:  "env2",
 					Value: "val2",
 				},
+                {
+                    Name: "configMapKeyRef",
+                    ValueFrom: &v1.EnvVarSource{
+                        ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+                            LocalObjectReference: v1.LocalObjectReference{
+                                Name: "configMapName",
+                            },
+                        },
+                    },
+                },
+                {
+                    Name: "fieldRef",
+                    ValueFrom: &v1.EnvVarSource{
+                        FieldRef: &v1.ObjectFieldSelector{
+                            FieldPath: "fieldPath",
+                        },
+                    },
+                },
+                {
+                    Name: "resourceFieldRef",
+                    ValueFrom: &v1.EnvVarSource{
+                        ResourceFieldRef: &v1.ResourceFieldSelector{
+                            ContainerName: "containerName",
+                            Resource:      "resourceField",
+                        },
+                    },
+                },
+                {
+                    Name: "secretKeyRef",
+                    ValueFrom: &v1.EnvVarSource{
+                        SecretKeyRef: &v1.SecretKeySelector{
+                            LocalObjectReference: v1.LocalObjectReference{
+                                Name: "secretName",
+                            },
+                        },
+                    },
+                },
 				{
 					Name:  "AZURE_STORAGE_ACCOUNT",
 					Value: "account123",
@@ -206,6 +243,43 @@ func Test_FLagSourceConfiguration_ToEnvVars(t *testing.T) {
 			Name:  "PRE_env2",
 			Value: "val2",
 		},
+        {
+            Name: "PRE_configMapKeyRef",
+            ValueFrom: &v1.EnvVarSource{
+                ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+                    LocalObjectReference: v1.LocalObjectReference{
+                        Name: "configMapName",
+                    },
+                },
+            },
+        },
+        {
+            Name: "PRE_fieldRef",
+            ValueFrom: &v1.EnvVarSource{
+                FieldRef: &v1.ObjectFieldSelector{
+                    FieldPath: "fieldPath",
+                },
+            },
+        },
+        {
+            Name: "PRE_resourceFieldRef",
+            ValueFrom: &v1.EnvVarSource{
+                ResourceFieldRef: &v1.ResourceFieldSelector{
+                    ContainerName: "containerName",
+                    Resource:      "resourceField",
+                },
+            },
+        },
+        {
+            Name: "PRE_secretKeyRef",
+            ValueFrom: &v1.EnvVarSource{
+                SecretKeyRef: &v1.SecretKeySelector{
+                    LocalObjectReference: v1.LocalObjectReference{
+                        Name: "secretName",
+                    },
+                },
+            },
+        },
 		{
 			Name:  "AZURE_STORAGE_ACCOUNT",
 			Value: "account123",

--- a/api/core/v1beta1/featureflagsource_types_test.go
+++ b/api/core/v1beta1/featureflagsource_types_test.go
@@ -238,6 +238,43 @@ func Test_FLagSourceConfiguration_ToEnvVars(t *testing.T) {
 					Name:  "env2",
 					Value: "val2",
 				},
+                {
+                    Name: "configMapKeyRef",
+                    ValueFrom: &v1.EnvVarSource{
+                        ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+                            LocalObjectReference: v1.LocalObjectReference{
+                                Name: "configMapName",
+                            },
+                        },
+                    },
+                },
+                {
+                    Name: "fieldRef",
+                    ValueFrom: &v1.EnvVarSource{
+                        FieldRef: &v1.ObjectFieldSelector{
+                            FieldPath: "fieldPath",
+                        },
+                    },
+                },
+                {
+                    Name: "resourceFieldRef",
+                    ValueFrom: &v1.EnvVarSource{
+                        ResourceFieldRef: &v1.ResourceFieldSelector{
+                            ContainerName: "containerName",
+                            Resource:      "resourceField",
+                        },
+                    },
+                },
+                {
+                    Name: "secretKeyRef",
+                    ValueFrom: &v1.EnvVarSource{
+                        SecretKeyRef: &v1.SecretKeySelector{
+                            LocalObjectReference: v1.LocalObjectReference{
+                                Name: "secretName",
+                            },
+                        },
+                    },
+                },
 				{
 					Name:  "AZURE_STORAGE_ACCOUNT",
 					Value: "account123",
@@ -276,6 +313,43 @@ func Test_FLagSourceConfiguration_ToEnvVars(t *testing.T) {
 			Name:  "PRE_env2",
 			Value: "val2",
 		},
+        {
+            Name: "PRE_configMapKeyRef",
+            ValueFrom: &v1.EnvVarSource{
+                ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+                    LocalObjectReference: v1.LocalObjectReference{
+                        Name: "configMapName",
+                    },
+                },
+            },
+        },
+        {
+            Name: "PRE_fieldRef",
+            ValueFrom: &v1.EnvVarSource{
+                FieldRef: &v1.ObjectFieldSelector{
+                    FieldPath: "fieldPath",
+                },
+            },
+        },
+        {
+            Name: "PRE_resourceFieldRef",
+            ValueFrom: &v1.EnvVarSource{
+                ResourceFieldRef: &v1.ResourceFieldSelector{
+                    ContainerName: "containerName",
+                    Resource:      "resourceField",
+                },
+            },
+        },
+        {
+            Name: "PRE_secretKeyRef",
+            ValueFrom: &v1.EnvVarSource{
+                SecretKeyRef: &v1.SecretKeySelector{
+                    LocalObjectReference: v1.LocalObjectReference{
+                        Name: "secretName",
+                    },
+                },
+            },
+        },
 		{
 			Name:  "AZURE_STORAGE_ACCOUNT",
 			Value: "account123",

--- a/api/core/v1beta1/inprocessconfiguration_types.go
+++ b/api/core/v1beta1/inprocessconfiguration_types.go
@@ -146,10 +146,17 @@ func (fc *InProcessConfigurationSpec) ToEnvVars() []corev1.EnvVar {
 	envs := []corev1.EnvVar{}
 
 	for _, envVar := range fc.EnvVars {
-		envs = append(envs, corev1.EnvVar{
-			Name:  common.EnvVarKey(fc.EnvVarPrefix, envVar.Name),
-			Value: envVar.Value,
-		})
+	    newEnvVar := corev1.EnvVar{
+            Name: common.EnvVarKey(fc.EnvVarPrefix, envVar.Name),
+        }
+
+        if envVar.Value != "" {
+            newEnvVar.Value = envVar.Value
+        } else if envVar.ValueFrom != nil {
+            newEnvVar.ValueFrom = envVar.ValueFrom
+        }
+
+        envs = append(envs, newEnvVar)
 	}
 
 	// default values are always included in the envVars

--- a/api/core/v1beta1/inprocessconfiguration_types.go
+++ b/api/core/v1beta1/inprocessconfiguration_types.go
@@ -146,17 +146,17 @@ func (fc *InProcessConfigurationSpec) ToEnvVars() []corev1.EnvVar {
 	envs := []corev1.EnvVar{}
 
 	for _, envVar := range fc.EnvVars {
-	    newEnvVar := corev1.EnvVar{
-            Name: common.EnvVarKey(fc.EnvVarPrefix, envVar.Name),
-        }
+		newEnvVar := corev1.EnvVar{
+			Name: common.EnvVarKey(fc.EnvVarPrefix, envVar.Name),
+		}
 
-        if envVar.Value != "" {
-            newEnvVar.Value = envVar.Value
-        } else if envVar.ValueFrom != nil {
-            newEnvVar.ValueFrom = envVar.ValueFrom
-        }
+		if envVar.Value != "" {
+			newEnvVar.Value = envVar.Value
+		} else if envVar.ValueFrom != nil {
+			newEnvVar.ValueFrom = envVar.ValueFrom
+		}
 
-        envs = append(envs, newEnvVar)
+		envs = append(envs, newEnvVar)
 	}
 
 	// default values are always included in the envVars

--- a/api/core/v1beta1/inprocessconfiguration_types_test.go
+++ b/api/core/v1beta1/inprocessconfiguration_types_test.go
@@ -116,6 +116,43 @@ func Test_InProcessConfiguration_ToEnvVars(t *testing.T) {
 					Name:  "env2",
 					Value: "val2",
 				},
+                {
+                    Name: "configMapKeyRef",
+                    ValueFrom: &v1.EnvVarSource{
+                        ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+                            LocalObjectReference: v1.LocalObjectReference{
+                                Name: "configMapName",
+                            },
+                        },
+                    },
+                },
+                {
+                    Name: "fieldRef",
+                    ValueFrom: &v1.EnvVarSource{
+                        FieldRef: &v1.ObjectFieldSelector{
+                            FieldPath: "fieldPath",
+                        },
+                    },
+                },
+                {
+                    Name: "resourceFieldRef",
+                    ValueFrom: &v1.EnvVarSource{
+                        ResourceFieldRef: &v1.ResourceFieldSelector{
+                            ContainerName: "containerName",
+                            Resource:      "resourceField",
+                        },
+                    },
+                },
+                {
+                    Name: "secretKeyRef",
+                    ValueFrom: &v1.EnvVarSource{
+                        SecretKeyRef: &v1.SecretKeySelector{
+                            LocalObjectReference: v1.LocalObjectReference{
+                                Name: "secretName",
+                            },
+                        },
+                    },
+                },
 			},
 			EnvVarPrefix:          "PRE",
 			Port:                  33,
@@ -137,6 +174,43 @@ func Test_InProcessConfiguration_ToEnvVars(t *testing.T) {
 			Name:  "PRE_env2",
 			Value: "val2",
 		},
+        {
+            Name: "PRE_configMapKeyRef",
+            ValueFrom: &v1.EnvVarSource{
+                ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+                    LocalObjectReference: v1.LocalObjectReference{
+                        Name: "configMapName",
+                    },
+                },
+            },
+        },
+        {
+            Name: "PRE_fieldRef",
+            ValueFrom: &v1.EnvVarSource{
+                FieldRef: &v1.ObjectFieldSelector{
+                    FieldPath: "fieldPath",
+                },
+            },
+        },
+        {
+            Name: "PRE_resourceFieldRef",
+            ValueFrom: &v1.EnvVarSource{
+                ResourceFieldRef: &v1.ResourceFieldSelector{
+                    ContainerName: "containerName",
+                    Resource:      "resourceField",
+                },
+            },
+        },
+        {
+            Name: "PRE_secretKeyRef",
+            ValueFrom: &v1.EnvVarSource{
+                SecretKeyRef: &v1.SecretKeySelector{
+                    LocalObjectReference: v1.LocalObjectReference{
+                        Name: "secretName",
+                    },
+                },
+            },
+        },
 		{
 			Name:  "PRE_HOST",
 			Value: "host",

--- a/docs/feature_flag_source.md
+++ b/docs/feature_flag_source.md
@@ -91,12 +91,32 @@ Given below is an example configuration with provider type `azblob` and supporte
 sources:
   - source: azblob://my-bucket/test.json # my-bucket - container name
     provider: azblob
-  envVars:
-    - name: AZURE_STORAGE_ACCOUNT
-      value: <account_name>
-    - name: AZURE_STORAGE_SAS_TOKEN
-      value: <SAS token>
+envVars:
+  - name: AZURE_STORAGE_ACCOUNT
+    value: <account_name>
+  - name: AZURE_STORAGE_SAS_TOKEN
+    value: <SAS token>
 ```
+
+Alternative way to provide credentials is to use Kubernetes secrets, for example:
+
+```yaml
+sources:
+  - source: azblob://my-bucket/test.json # my-bucket - container name
+    provider: azblob
+envVars:
+  - name: AZURE_STORAGE_ACCOUNT
+    valueFrom:
+      secretKeyRef:
+        name: my-secret
+        key: account_name
+  - name: AZURE_STORAGE_SAS_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: my-secret
+        key: sas_token
+```
+
 Other type of credentials for Azure Blob Storage are supported, for details (see [AZ credentials config](https://pkg.go.dev/gocloud.dev/blob/azureblob#hdr-URLs))
 
 ## Sidecar configurations

--- a/docs/feature_flag_source.md
+++ b/docs/feature_flag_source.md
@@ -115,29 +115,25 @@ envVars:
     value: <SAS token>
 ```
 
-Alternative way to provide credentials is to use Kubernetes secrets, for example:
-
-```yaml
-sources:
-  - source: azblob://my-bucket/test.json # my-bucket - container name
-    provider: azblob
-envVars:
-  - name: AZURE_STORAGE_ACCOUNT
-    valueFrom:
-      secretKeyRef:
-        name: my-secret
-        key: account_name
-  - name: AZURE_STORAGE_SAS_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: my-secret
-        key: sas_token
-```
-
 Other types of credentials for Azure Blob Storage are supported; for details see
 [AZ credentials config](https://pkg.go.dev/gocloud.dev/blob/azureblob#hdr-URLs).
 
 #### Google Cloud Storage
+
+## Environment variables
+
+`envVars` can be used to pass environment variables to the injected flagd sidecar. Values can be set inline or referenced from Kubernetes secrets:
+
+```yaml
+envVars:
+  - name: MY_VAR
+    value: my-value           # inline value
+  - name: MY_SECRET_VAR
+    valueFrom:                # value from a Kubernetes secret
+      secretKeyRef:
+        name: my-secret
+        key: my-key
+```
 
 ## Sidecar configurations
 

--- a/docs/feature_flag_source.md
+++ b/docs/feature_flag_source.md
@@ -115,59 +115,29 @@ envVars:
     value: <SAS token>
 ```
 
+Alternative way to provide credentials is to use Kubernetes secrets, for example:
+
+```yaml
+sources:
+  - source: azblob://my-bucket/test.json # my-bucket - container name
+    provider: azblob
+envVars:
+  - name: AZURE_STORAGE_ACCOUNT
+    valueFrom:
+      secretKeyRef:
+        name: my-secret
+        key: account_name
+  - name: AZURE_STORAGE_SAS_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: my-secret
+        key: sas_token
+```
+
 Other types of credentials for Azure Blob Storage are supported; for details see
 [AZ credentials config](https://pkg.go.dev/gocloud.dev/blob/azureblob#hdr-URLs).
 
 #### Google Cloud Storage
-
-Given below is an example configuration with provider type `gcs` and supported options,
-
-```yaml
-sources:
-  - source: gs://my-bucket/flags.json # my-bucket - GCS bucket name
-    provider: gcs
-    interval: 10                      # optional polling interval in seconds, defaults to 5
-envVars:
-  - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /var/run/secrets/gcp/key.json
-```
-
-On GKE, prefer [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
-over static credentials. For the full set of supported URL options see
-the [gocloud `blob/gcsblob` URL reference](https://pkg.go.dev/gocloud.dev/blob/gcsblob#hdr-URLs).
-
-#### Amazon S3
-
-Given below is an example configuration with provider type `s3` and supported options,
-
-```yaml
-sources:
-  - source: s3://my-bucket/flags.json # my-bucket - S3 bucket name
-    provider: s3
-    interval: 10                      # optional polling interval in seconds, defaults to 5
-envVars:
-  - name: AWS_REGION
-    value: us-east-1
-  - name: AWS_ACCESS_KEY_ID
-    valueFrom:
-      secretKeyRef:
-        name: s3-credentials
-        key: access-key-id
-  - name: AWS_SECRET_ACCESS_KEY
-    valueFrom:
-      secretKeyRef:
-        name: s3-credentials
-        key: secret-access-key
-```
-
-On EKS, prefer [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
-or EKS Pod Identity over static access keys; both auto-inject the right
-`AWS_*` variables via the pod's service account.
-
-For S3-compatible endpoints such as MinIO or LocalStack, set
-`AWS_ENDPOINT_URL_S3` and (usually) `AWS_S3_FORCE_PATH_STYLE=true`, or pass
-URL query parameters directly on the source URI. See the [gocloud `blob/s3blob` URL reference](https://pkg.go.dev/gocloud.dev/blob/s3blob#hdr-URLs)
-for the full set of supported URL options.
 
 ## Sidecar configurations
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Allow to configure `envVars` using `valueFrom` field.
Verified that the Flagd sidecar is created with the configured source (secrets or config map).

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->
\-
### Notes
According to the CRD documentation for [FeatureFlagSource](https://github.com/open-feature/open-feature-operator/blob/main/docs/crds.md#featureflagsourcespecenvvarsindexvaluefrom) and [InProcessConfiguration](https://github.com/open-feature/open-feature-operator/blob/main/docs/crds.md#inprocessconfigurationspecenvvarsindexvaluefrom), it is possible to configure the source for the environment variable's value in the `valueFrom` field. In reality, the `envVars` could be configured using only the `value` field.

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->
\-
### How to test
<!-- if applicable, add testing instructions under this section -->

Works with `end-to-end.yaml`
```yaml
apiVersion: core.openfeature.dev/v1beta1
kind: FeatureFlagSource
metadata:
  name: end-to-end
  namespace: open-feature-demo
spec:
  sources:
    - source: azblob://my-bucket/test.json
      provider: azblob
  envVarPrefix: ""
  envVars:
    - name: AZURE_STORAGE_ACCOUNT
      valueFrom:
        secretKeyRef:
          name: my-secret
          key: account_name
    - name: AZURE_STORAGE_SAS_TOKEN
      valueFrom:
        secretKeyRef:
          name: my-secret
          key: sas_token
```