### PR TITLE
fix: correct capabilities drop value to "ALL" for PodSecurity restricted compliance

### DIFF
--- a/internal/common/flagdinjector/flagdinjector.go
+++ b/internal/common/flagdinjector/flagdinjector.go
@@ -489,7 +489,7 @@ func getSecurityContext() *corev1.SecurityContext {
 		// flagd does not require any additional capabilities, no bits set
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{
-				"all",
+				"ALL",
 			},
 		},
 		RunAsUser:  &user,

--- a/internal/common/flagdinjector/flagdinjector_test.go
+++ b/internal/common/flagdinjector/flagdinjector_test.go
@@ -900,7 +900,7 @@ func getExpectedPod(namespace string) v1.Pod {
 					SecurityContext: &v1.SecurityContext{
 						Capabilities: &v1.Capabilities{
 							Drop: []v1.Capability{
-								"all",
+								"ALL",
 							},
 						},
 						Privileged:               utils.FalseVal(),
@@ -979,7 +979,7 @@ func Test_getSecurityContext(t *testing.T) {
 		// flagd does not require any additional capabilities, no bits set
 		Capabilities: &v1.Capabilities{
 			Drop: []v1.Capability{
-				"all",
+				"ALL",
 			},
 		},
 		RunAsUser:  &user,


### PR DESCRIPTION
```
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

Fixes the injected `flagd` sidecar container failing admission under Kubernetes PodSecurity `restricted` policy.

When the operator injects the `flagd` sidecar via `generateBasicFlagdContainer()`, the `getSecurityContext()` function set `capabilities.drop` to `"all"` (lowercase):

```go
Capabilities: &corev1.Capabilities{
    Drop: []corev1.Capability{
        "all",  // ❌ lowercase — PSA rejects this
    },
},
```

The Kubernetes Pod Security Admission controller performs a case-sensitive comparison against the constant capabilityAll = "ALL" in check_capabilities_restricted.go: 

`if c == capabilityAll {  // exact match: "ALL" != "all"`

This means any namespace enforcing pod-security.kubernetes.io/enforce: restricted rejects all pods with an injected flagd sidecar with:

```
pods "<name>" is forbidden: violates PodSecurity "restricted:v1.24":
unrestricted capabilities (container "flagd" must set securityContext.capabilities.drop=["ALL"])
```
This PR changes the drop value to uppercase "ALL" to match the exact value required by the PSA restricted policy check:

```
Capabilities: &corev1.Capabilities{
    Drop: []corev1.Capability{
        "ALL",  // ✅ matches capabilityAll constant in PSA
    },
},
```
Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Notes
This affects all users running clusters with PodSecurity restricted enforcement on namespaces where the operator injects the flagd sidecar. There is no behaviour change to flagd itself — capabilities were always intended to be fully dropped, per the existing comment in the code.

How to test
Create a namespace with pod-security.kubernetes.io/enforce: restricted
Deploy a pod with the openfeature.dev/enabled: "true" annotation so the operator injects the flagd sidecar
Confirm the pod is admitted successfully and the flagd container has securityContext.capabilities.drop=["ALL"]