### PR TITLE
fix(security): pin all GitHub Actions to SHA digests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: 'go.mod'
 
@@ -35,7 +35,7 @@ jobs:
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Module cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         env:
           cache-name: go-mod-cache
         with:
@@ -49,7 +49,7 @@ jobs:
         run: make unit-test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           flags: unit-tests
 
@@ -59,17 +59,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           platforms: all
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
@@ -78,7 +78,7 @@ jobs:
           cache-from: type=gha,scope=${{ github.ref_name }}-ofo
           cache-to: type=gha,scope=${{ github.ref_name }}-ofo
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           input: ${{ github.workspace }}/open-feature-operator-local.tar
           format: "sarif"
@@ -88,11 +88,11 @@ jobs:
           # use an alternative trivvy db to avoid rate limits
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
         with:
           sarif_file: "trivy-results.sarif"
       - name: Upload image as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: open-feature-operator-local-${{ github.sha }}
           path: ${{ github.workspace }}/open-feature-operator-local.tar

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    "group:recommended"
+    "group:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "ignorePaths": [],
   "semanticCommits": "enabled",


### PR DESCRIPTION
## Summary

- Pin **all** GitHub Actions in `pr-checks.yml` from mutable version tags to commit SHA digests
- Update `aquasecurity/trivy-action` from `@0.29.0` to SHA-pinned `v0.35.0` (`57a97c7`) in response to CVE-2026-26189
- Add `helpers:pinGitHubActionDigests` to renovate config for automatic SHA pinning of future action updates

## Context

On March 19, 2026 an attacker force-pushed 75 existing tags in `aquasecurity/trivy-action` to malicious commits that exfiltrated CI/CD secrets. Any workflow referencing trivy-action by a mutable tag (rather than a commit SHA) was potentially vulnerable. See [Upwind's incident breakdown](https://www.upwind.io/feed/trivy-supply-chain-incident-github-actions-compromise-breakdown) for details.

### Impact assessment

**This repo was not impacted.** We verified via the GitHub Actions API that no runs of the `ci` workflow from origin branches occurred during the attack window (March 19, 17:00-23:13 UTC). The only runs on March 19 were from fork PRs, which were held for approval (`action_required`) and never executed.

Additionally, sensitive secrets (signing keys, publishing tokens, etc.) are only available in protected environments scoped to specific branches (e.g., `main`), so even if a PR branch run had been compromised, those secrets would not have been exposed.

However, all actions in `pr-checks.yml` used mutable tags, leaving the repo vulnerable to this class of supply chain attack.

## Changes

| File | Change |
|---|---|
| `.github/workflows/pr-checks.yml` | Pin all 9 action references to commit SHA digests |
| `renovate.json` | Add `helpers:pinGitHubActionDigests` preset |

### Actions pinned

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@34e1148...` (v4) |
| `actions/setup-go` | `@v5` | `@40f1582...` (v5) |
| `actions/cache` | `@v4` | `@0057852...` (v4) |
| `codecov/codecov-action` | `@v4` | `@b9fd7d1...` (v4) |
| `docker/setup-qemu-action` | `@v3` | `@c7c5346...` (v3) |
| `docker/setup-buildx-action` | `@v3` | `@8d2750c...` (v3) |
| `docker/build-push-action` | `@v6` | `@10e90e3...` (v6) |
| `aquasecurity/trivy-action` | `@0.29.0` | `@57a97c7...` (v0.35.0) |
| `github/codeql-action/upload-sarif` | `@v2` | `@b8d3b6e...` (v2) |
| `actions/upload-artifact` | `@v4` | `@ea165f8...` (v4) |