### PR TITLE
test: wait for gateway API CRDs before e2e assert

### DIFF
--- a/test/e2e/chainsaw/flagd-with-gateway-api/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/flagd-with-gateway-api/chainsaw-test.yaml
@@ -10,6 +10,8 @@ spec:
       try:
         - apply:
             file: ../assets/gateway-api.yaml
+        - script:
+            content: kubectl wait --for condition=Established crd/httproutes.gateway.networking.k8s.io --timeout=60s
     - name: step-01
       try:
         - apply:


### PR DESCRIPTION
## Summary
- Fix race in `flagd-with-gateway-api` e2e test where the HTTPRoute assert fails because the Gateway API CRDs aren't fully established yet
- Add `kubectl wait --for condition=Established` after applying the CRDs