### PR TITLE
chore: migrate Renovate config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    "group:recommended",
+    "config:recommended",
     "helpers:pinGitHubActionDigests"
   ],
   "ignorePaths": [],
-  "semanticCommits": "enabled",
   "labels": [
     "renovate"
   ],
@@ -39,7 +37,7 @@
       "extractVersion": "^flagd-proxy/(?<version>.*?)$"
     }
   ],
-  "regexManagers": [
+  "customManagers": [
     {
       "fileMatch": [
         "(^|\\/)Makefile$",
@@ -52,7 +50,8 @@
       "matchStrings": [
         "(#|\\/\\/) renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)\\s.*?(?<separator>\\??=|\\: ?) ?\\\"?(?<currentValue>.+?)?\\\"?\\s",
         "(#|\\/\\/) renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)\\s.*?default:\"(?<currentValue>.+?)\""
-      ]
+      ],
+      "customType": "regex"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- migrate Renovate from `config:base` to `config:recommended`
- migrate the regex manager block to Renovate custom managers while preserving the existing match/file patterns

## Verification
- `python3 -m json.tool renovate.json`
- `git diff --check`

No runtime or cluster tests were run; this is a Renovate config-only change.