### PR TITLE
fix: Align FeatureFlagSource CRD defaults with documentation

### DIFF
--- a/api/core/v1beta1/featureflagsource_types.go
+++ b/api/core/v1beta1/featureflagsource_types.go
@@ -75,8 +75,8 @@ type FeatureFlagSourceSpec struct {
 
 	// RolloutOnChange dictates whether annotated deployments will be restarted when configuration changes are
 	// detected in this CR, defaults to false
-	// +kubebuilder:default:=false
 	// +optional
+	// +kubebuilder:default:=false
 	RolloutOnChange *bool `json:"rolloutOnChange"`
 
 	// ProbesEnabled defines whether to enable liveness and readiness probes of flagd sidecar. Default true (enabled).

--- a/api/core/v1beta1/featureflagsource_types.go
+++ b/api/core/v1beta1/featureflagsource_types.go
@@ -80,8 +80,8 @@ type FeatureFlagSourceSpec struct {
 	RolloutOnChange *bool `json:"rolloutOnChange"`
 
 	// ProbesEnabled defines whether to enable liveness and readiness probes of flagd sidecar. Default true (enabled).
-	// +kubebuilder:default:=true
 	// +optional
+	// +kubebuilder:default:=true
 	ProbesEnabled *bool `json:"probesEnabled"`
 
 	// DebugLogging defines whether to enable --debug flag of flagd sidecar. Default false (disabled).

--- a/api/core/v1beta1/featureflagsource_types.go
+++ b/api/core/v1beta1/featureflagsource_types.go
@@ -75,14 +75,17 @@ type FeatureFlagSourceSpec struct {
 
 	// RolloutOnChange dictates whether annotated deployments will be restarted when configuration changes are
 	// detected in this CR, defaults to false
+	// +kubebuilder:default:=false
 	// +optional
 	RolloutOnChange *bool `json:"rolloutOnChange"`
 
 	// ProbesEnabled defines whether to enable liveness and readiness probes of flagd sidecar. Default true (enabled).
+	// +kubebuilder:default:=true
 	// +optional
 	ProbesEnabled *bool `json:"probesEnabled"`
 
 	// DebugLogging defines whether to enable --debug flag of flagd sidecar. Default false (disabled).
+	// +kubebuilder:default:=false
 	// +optional
 	DebugLogging *bool `json:"debugLogging"`
 
@@ -146,8 +149,7 @@ type Source struct {
 }
 
 // FeatureFlagSourceStatus defines the observed state of FeatureFlagSource
-type FeatureFlagSourceStatus struct {
-}
+type FeatureFlagSourceStatus struct{}
 
 //+kubebuilder:resource:shortName="ffs"
 //+kubebuilder:object:root=true

--- a/api/core/v1beta1/featureflagsource_types.go
+++ b/api/core/v1beta1/featureflagsource_types.go
@@ -85,8 +85,8 @@ type FeatureFlagSourceSpec struct {
 	ProbesEnabled *bool `json:"probesEnabled"`
 
 	// DebugLogging defines whether to enable --debug flag of flagd sidecar. Default false (disabled).
-	// +kubebuilder:default:=false
 	// +optional
+	// +kubebuilder:default:=false
 	DebugLogging *bool `json:"debugLogging"`
 
 	// OtelCollectorUri defines whether to enable --otel-collector-uri flag of flagd sidecar. Default false (disabled).

--- a/config/crd/bases/core.openfeature.dev_featureflagsources.yaml
+++ b/config/crd/bases/core.openfeature.dev_featureflagsources.yaml
@@ -54,6 +54,7 @@ spec:
                   type: string
                 type: array
               debugLogging:
+                default: false
                 description: DebugLogging defines whether to enable --debug flag of
                   flagd sidecar. Default false (disabled).
                 type: boolean
@@ -222,6 +223,7 @@ spec:
                 format: int32
                 type: integer
               probesEnabled:
+                default: true
                 description: ProbesEnabled defines whether to enable liveness and
                   readiness probes of flagd sidecar. Default true (enabled).
                 type: boolean
@@ -286,6 +288,7 @@ spec:
                     type: object
                 type: object
               rolloutOnChange:
+                default: false
                 description: |-
                   RolloutOnChange dictates whether annotated deployments will be restarted when configuration changes are
                   detected in this CR, defaults to false

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -295,6 +295,8 @@ FeatureFlagSourceSpec defines the desired state of FeatureFlagSource
         <td>boolean</td>
         <td>
           DebugLogging defines whether to enable --debug flag of flagd sidecar. Default false (disabled).<br/>
+          <br/>
+            <i>Default</i>: false<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -388,6 +390,8 @@ are added at the lowest index, all values will have the EnvVarPrefix applied, de
         <td>boolean</td>
         <td>
           ProbesEnabled defines whether to enable liveness and readiness probes of flagd sidecar. Default true (enabled).<br/>
+          <br/>
+            <i>Default</i>: true<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -403,6 +407,8 @@ are added at the lowest index, all values will have the EnvVarPrefix applied, de
         <td>
           RolloutOnChange dictates whether annotated deployments will be restarted when configuration changes are
 detected in this CR, defaults to false<br/>
+          <br/>
+            <i>Default</i>: false<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->
Aligns `FeatureFlagSource` CRD defaults with what is stated in the documentation.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes https://github.com/open-feature/open-feature-operator/issues/837

### How to test
- See https://github.com/open-feature/open-feature-operator/issues/837

