### PR TITLE
fix: Update kubeVersion to allow pre-releases

### DIFF
--- a/chart/open-feature-operator/Chart.yaml
+++ b/chart/open-feature-operator/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: "v0.9.1" # x-release-please-version
-kubeVersion: ">=1.29.0"
+kubeVersion: ">=1.29.0-0"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.


### PR DESCRIPTION
## This PR
Makes helm accept pre-releases.

We're trying to upgrade from 0.8.9 to 0.9.1 on EKS (v1.33.10-eks-bbe087e). Unfortunately Helm's semver logic treats v1.33.10-eks-bbe087e as *lower* than 1.29.0 so we're stuck.

### Related Issues

### Notes
Alternative:
Unferified but IIUC Helm would accept v1.33.10+eks-bbe087e (+ instead of -). I don't think I'll be able to convince AWS of this though.

### Follow-up Tasks

### How to test
I guess the easiest way would be to try to install this on an EKS cluster.

