### PR TITLE
feat: publish Helm chart as an OCI artifact to ghcr.io

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -182,3 +182,49 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ env.GITHUB_PAGES_BRANCH }}
+
+  release-charts-oci:
+    needs: release-please
+    permissions:
+      contents: read
+      packages: write # to push the Helm chart as an OCI artifact
+    runs-on: ubuntu-24.04
+    if: ${{ needs.release-please.outputs.release_created }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.release-please.outputs.release_tag_name }}
+
+      - name: Setup go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.DEFAULT_GO_VERSION }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@327cd5a69de6c009b9ce71bce8395f28e651bf99
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package and push the Helm chart as an OCI artifact
+        run: |
+          make workspace-init
+          go mod tidy
+          make controller-gen
+          IMG=ghcr.io/open-feature/open-feature-operator:${{ needs.release-please.outputs.release_tag_name }} make helm-package
+          make helm-push-oci CHART_OCI_REGISTRY=oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4
+        with:
+          cosign-release: 'v2.6.0'
+
+      - name: Sign the published Helm chart
+        run: |
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/open-feature-operator:${{ needs.release-please.outputs.release_tag_name }}
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        if: ${{ env.DRY_RUN != 'true' }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,7 +53,7 @@ jobs:
           ref: ${{ needs.release-please.outputs.release_tag_name }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@327cd5a69de6c009b9ce71bce8395f28e651bf99
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -202,19 +202,22 @@ jobs:
           go-version: ${{ env.DEFAULT_GO_VERSION }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@327cd5a69de6c009b9ce71bce8395f28e651bf99
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package and push the Helm chart as an OCI artifact
+        env:
+          RELEASE_TAG: ${{ needs.release-please.outputs.release_tag_name }}
+          OWNER: ${{ github.repository_owner }}
         run: |
           make workspace-init
           go mod tidy
           make controller-gen
-          IMG=ghcr.io/open-feature/open-feature-operator:${{ needs.release-please.outputs.release_tag_name }} make helm-package
-          make helm-push-oci CHART_OCI_REGISTRY=oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
+          IMG="ghcr.io/open-feature/open-feature-operator:${RELEASE_TAG}" make helm-package
+          make helm-push-oci CHART_OCI_REGISTRY="oci://${REGISTRY}/${OWNER}/charts"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4
@@ -222,9 +225,11 @@ jobs:
           cosign-release: 'v2.6.0'
 
       - name: Sign the published Helm chart
-        run: |
-          cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/open-feature-operator:${{ needs.release-please.outputs.release_tag_name }}
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          RELEASE_TAG: ${{ needs.release-please.outputs.release_tag_name }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${REGISTRY}/${OWNER}/charts/open-feature-operator:${RELEASE_TAG}"
         if: ${{ env.DRY_RUN != 'true' }}

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ IMG?=$(RELEASE_REGISTRY)/$(RELEASE_IMAGE)
 # customize overlay to be used in the build, DEFAULT or HELM
 KUSTOMIZE_OVERLAY ?= DEFAULT
 CHART_VERSION=v0.9.2# x-release-please-version
+# OCI registry the packaged Helm chart is pushed to (helm appends the chart name).
+CHART_OCI_REGISTRY?=oci://ghcr.io/open-feature/charts
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.26.1
 WAIT_TIMEOUT_SECONDS?=60
@@ -256,6 +258,10 @@ helm-package: set-helm-overlay generate release-manifests helm
 	mkdir -p charts && mv open-feature-operator-*.tgz charts
 	$(HELM) repo index --url https://open-feature.github.io/open-feature-operator/charts charts
 	mv charts/index.yaml index.yaml
+
+.PHONY: helm-push-oci
+helm-push-oci: helm ## Push the packaged Helm chart to an OCI registry (run helm-package first; requires a prior helm/docker registry login).
+	$(HELM) push charts/open-feature-operator-$(CHART_VERSION).tgz $(CHART_OCI_REGISTRY)
 
 install-mockgen:
 	go install github.com/golang/mock/mockgen@v1.6.0

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,6 +22,18 @@ helm repo update &&
 helm upgrade --install openfeature openfeature/open-feature-operator
 ```
 
+### OCI registry
+
+The chart is also published as an OCI artifact to GitHub Container Registry, signed with [cosign](https://github.com/sigstore/cosign). This is convenient if you want to mirror or proxy it through your own registry (e.g. JFrog Artifactory, Harbor).
+
+<!-- x-release-please-start-version -->
+```sh
+helm upgrade --install openfeature \
+  oci://ghcr.io/open-feature/charts/open-feature-operator \
+  --version v0.9.2
+```
+<!-- x-release-please-end -->
+
 ### Upgrading
 
 ```sh


### PR DESCRIPTION
## Summary

Publishes the operator's Helm chart as an **OCI artifact** to GitHub Container Registry, in addition to the existing classic (gh-pages) chart repository. This gives consumers a second, OCI-native distribution channel that can be pulled directly with `helm` and proxied/mirrored through OCI-aware registries such as JFrog Artifactory or Harbor.

- New `release-charts-oci` job in `release-please.yml` that, on a created release:
  - packages the chart (`make helm-package`),
  - pushes it to `oci://ghcr.io/<owner>/charts` → `ghcr.io/open-feature/charts/open-feature-operator:<version>`,
  - signs the OCI artifact with cosign, reusing the existing `COSIGN_PRIVATE_KEY`/`COSIGN_PASSWORD` secrets, for parity with the operator image.
- New `helm-push-oci` Make target + `CHART_OCI_REGISTRY` variable so the push can be run/overridden locally.
- `docs/installation.md`: documents the OCI install path (wrapped in release-please version markers so it stays in sync).

The existing classic chart flow (`release-charts` → gh-pages + `index.yaml`) and the `helm repo add` install path are **unchanged** — both distribution methods are available.

### Why a separate OCI path

The container image already occupies `ghcr.io/<owner>/open-feature-operator`. To avoid a tag collision between the image and the chart, the chart is published under a `charts/` sub-namespace: `ghcr.io/open-feature/charts/open-feature-operator`.

### Install example

<!-- x-release-please-start-version -->
```sh
helm upgrade --install openfeature \
  oci://ghcr.io/open-feature/charts/open-feature-operator \
  --version v0.9.2
```
<!-- x-release-please-end -->

## Operational note for maintainers

On the first release after merge, GHCR will create a new package `charts/open-feature-operator` under the `open-feature` org. It will default to **private** — a maintainer will need to set its visibility to **public** and link it to the repo so the published chart is pullable anonymously (same one-time step the image package needed). The `GITHUB_TOKEN` in the job has `packages: write`, which is sufficient to create and push to the package.

## Test plan

- [x] `make -n helm-push-oci` resolves to `helm push charts/open-feature-operator-v0.9.2.tgz oci://ghcr.io/open-feature/charts` (filename matches `helm-package` output).
- [x] Workflow YAML parses; `release-charts-oci` mirrors the existing signed `build-oci` job (pinned action SHAs, `packages: write`, cosign sign step).
- [ ] End-to-end OCI push + cosign sign can only be exercised by the release pipeline post-merge (requires GHCR auth + cosign secrets). Recommend confirming the package is pullable and the signature verifies (`cosign verify --key <pub> ghcr.io/open-feature/charts/open-feature-operator:<tag>`) after the first release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)