### PR TITLE
feat: expose flagd sync-server keepalive settings on FeatureFlagSource

### DIFF
--- a/api/core/v1beta1/common/common.go
+++ b/api/core/v1beta1/common/common.go
@@ -21,36 +21,38 @@ const (
 )
 
 const (
-	ManagementPortEnvVar        string = "MANAGEMENT_PORT"
-	PortEnvVar                  string = "PORT"
-	HostEnvVar                  string = "HOST"
-	TLSEnvVar                   string = "TLS"
-	SocketPathEnvVar            string = "SOCKET_PATH"
-	OfflineFlagSourcePathEnvVar string = "OFFLINE_FLAG_SOURCE_PATH"
-	SelectorEnvVar              string = "SOURCE_SELECTOR"
-	CacheEnvVar                 string = "CACHE"
-	CacheMaxSizeEnvVar          string = "MAX_CACHE_SIZE"
-	ResolverEnvVar              string = "RESOLVER"
-	EvaluatorEnvVar             string = "EVALUATOR"
-	ImageEnvVar                 string = "IMAGE"
-	VersionEnvVar               string = "TAG"
-	ProviderArgsEnvVar          string = "PROVIDER_ARGS"
-	DefaultSyncProviderEnvVar   string = "SYNC_PROVIDER"
-	LogFormatEnvVar             string = "LOG_FORMAT"
-	ProbesEnabledVar            string = "PROBES_ENABLED"
-	DefaultEnvVarPrefix         string = "FLAGD"
-	DefaultManagementPort       int32  = 8014
-	DefaultRPCPort              int32  = 8013
-	DefaultInProcessPort        int32  = 8015
-	DefaultEvaluator            string = "json"
-	DefaultLogFormat            string = "json"
-	DefaultProbesEnabled        bool   = true
-	DefaultTLS                  bool   = false
-	DefaultHost                 string = "localhost"
-	DefaultCache                string = "lru"
-	DefaultCacheMaxSize         int32  = 1000
-	InProcessResolverType       string = "in-process"
-	RPCResolverType             string = "rpc"
+	ManagementPortEnvVar               string = "MANAGEMENT_PORT"
+	PortEnvVar                         string = "PORT"
+	HostEnvVar                         string = "HOST"
+	TLSEnvVar                          string = "TLS"
+	SocketPathEnvVar                   string = "SOCKET_PATH"
+	OfflineFlagSourcePathEnvVar        string = "OFFLINE_FLAG_SOURCE_PATH"
+	SelectorEnvVar                     string = "SOURCE_SELECTOR"
+	CacheEnvVar                        string = "CACHE"
+	CacheMaxSizeEnvVar                 string = "MAX_CACHE_SIZE"
+	ResolverEnvVar                     string = "RESOLVER"
+	EvaluatorEnvVar                    string = "EVALUATOR"
+	ImageEnvVar                        string = "IMAGE"
+	VersionEnvVar                      string = "TAG"
+	ProviderArgsEnvVar                 string = "PROVIDER_ARGS"
+	DefaultSyncProviderEnvVar          string = "SYNC_PROVIDER"
+	LogFormatEnvVar                    string = "LOG_FORMAT"
+	KeepAliveMinTimeEnvVar             string = "KEEP_ALIVE_MIN_TIME"
+	KeepAlivePermitWithoutStreamEnvVar string = "KEEP_ALIVE_PERMIT_WITHOUT_STREAM"
+	ProbesEnabledVar                   string = "PROBES_ENABLED"
+	DefaultEnvVarPrefix                string = "FLAGD"
+	DefaultManagementPort              int32  = 8014
+	DefaultRPCPort                     int32  = 8013
+	DefaultInProcessPort               int32  = 8015
+	DefaultEvaluator                   string = "json"
+	DefaultLogFormat                   string = "json"
+	DefaultProbesEnabled               bool   = true
+	DefaultTLS                         bool   = false
+	DefaultHost                        string = "localhost"
+	DefaultCache                       string = "lru"
+	DefaultCacheMaxSize                int32  = 1000
+	InProcessResolverType              string = "in-process"
+	RPCResolverType                    string = "rpc"
 )
 
 func (s SyncProviderType) IsKubernetes() bool {

--- a/api/core/v1beta1/featureflagsource_types.go
+++ b/api/core/v1beta1/featureflagsource_types.go
@@ -346,5 +346,19 @@ func (fc *FeatureFlagSourceSpec) ToEnvVars() []corev1.EnvVar {
 		})
 	}
 
+	if fc.KeepAliveMinTime != nil {
+		envs = append(envs, corev1.EnvVar{
+			Name:  common.EnvVarKey(fc.EnvVarPrefix, common.KeepAliveMinTimeEnvVar),
+			Value: fc.KeepAliveMinTime.Duration.String(),
+		})
+	}
+
+	if fc.KeepAlivePermitWithoutStream != nil {
+		envs = append(envs, corev1.EnvVar{
+			Name:  common.EnvVarKey(fc.EnvVarPrefix, common.KeepAlivePermitWithoutStreamEnvVar),
+			Value: fmt.Sprintf("%t", *fc.KeepAlivePermitWithoutStream),
+		})
+	}
+
 	return envs
 }

--- a/api/core/v1beta1/featureflagsource_types.go
+++ b/api/core/v1beta1/featureflagsource_types.go
@@ -113,6 +113,16 @@ type FeatureFlagSourceSpec struct {
 	// +optional
 	// +kubebuilder:default:=8016
 	OFREPPort int32 `json:"ofrepPort"`
+
+	// KeepAliveMinTime sets the minimum interval the flagd sync server permits
+	// between client keepalive pings. When unset, flagd's own default applies.
+	// +optional
+	KeepAliveMinTime *metav1.Duration `json:"keepAliveMinTime,omitempty"`
+
+	// KeepAlivePermitWithoutStream permits client keepalive pings even when there
+	// is no active stream. When unset, flagd's own default applies.
+	// +optional
+	KeepAlivePermitWithoutStream *bool `json:"keepAlivePermitWithoutStream,omitempty"`
 }
 
 type Source struct {
@@ -264,6 +274,12 @@ func (fc *FeatureFlagSourceSpec) Merge(new *FeatureFlagSourceSpec) {
 	}
 	if new.OFREPPort != 0 {
 		fc.OFREPPort = new.OFREPPort
+	}
+	if new.KeepAliveMinTime != nil {
+		fc.KeepAliveMinTime = new.KeepAliveMinTime
+	}
+	if new.KeepAlivePermitWithoutStream != nil {
+		fc.KeepAlivePermitWithoutStream = new.KeepAlivePermitWithoutStream
 	}
 }
 

--- a/api/core/v1beta1/featureflagsource_types_test.go
+++ b/api/core/v1beta1/featureflagsource_types_test.go
@@ -2,11 +2,13 @@ package v1beta1
 
 import (
 	"testing"
+	"time"
 
 	"github.com/open-feature/open-feature-operator/api/core/v1beta1/common"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_FLagSourceConfiguration_Merge(t *testing.T) {
@@ -396,4 +398,24 @@ func Test_FLagSourceConfiguration_ToEnvVars(t *testing.T) {
 		},
 	}
 	require.Equal(t, expected, ff.Spec.ToEnvVars())
+}
+
+func Test_FLagSourceConfiguration_Merge_Keepalive(t *testing.T) {
+	base := &FeatureFlagSourceSpec{}
+	// override sets both keepalive fields
+	permit := true
+	base.Merge(&FeatureFlagSourceSpec{
+		KeepAliveMinTime:             &metav1.Duration{Duration: 45 * time.Second},
+		KeepAlivePermitWithoutStream: &permit,
+	})
+	require.NotNil(t, base.KeepAliveMinTime)
+	require.Equal(t, 45*time.Second, base.KeepAliveMinTime.Duration)
+	require.NotNil(t, base.KeepAlivePermitWithoutStream)
+	require.True(t, *base.KeepAlivePermitWithoutStream)
+
+	// nil override must not clobber existing values
+	base.Merge(&FeatureFlagSourceSpec{})
+	require.NotNil(t, base.KeepAliveMinTime)
+	require.Equal(t, 45*time.Second, base.KeepAliveMinTime.Duration)
+	require.NotNil(t, base.KeepAlivePermitWithoutStream)
 }

--- a/api/core/v1beta1/featureflagsource_types_test.go
+++ b/api/core/v1beta1/featureflagsource_types_test.go
@@ -438,6 +438,15 @@ func Test_FLagSourceConfiguration_ToEnvVars_Keepalive(t *testing.T) {
 	require.Contains(t, got, v1.EnvVar{Name: "FLAGD_KEEP_ALIVE_MIN_TIME", Value: "45s"})
 	require.Contains(t, got, v1.EnvVar{Name: "FLAGD_KEEP_ALIVE_PERMIT_WITHOUT_STREAM", Value: "true"})
 
+	// set false: explicitly disabling permit-without-stream still emits the env var
+	permitFalse := false
+	setFalse := FeatureFlagSourceSpec{
+		EnvVarPrefix:                 "FLAGD",
+		KeepAlivePermitWithoutStream: &permitFalse,
+	}
+	gotFalse := setFalse.ToEnvVars()
+	require.Contains(t, gotFalse, v1.EnvVar{Name: "FLAGD_KEEP_ALIVE_PERMIT_WITHOUT_STREAM", Value: "false"})
+
 	// mixed: only the set field is emitted
 	mixed := FeatureFlagSourceSpec{
 		EnvVarPrefix:     "FLAGD",

--- a/api/core/v1beta1/featureflagsource_types_test.go
+++ b/api/core/v1beta1/featureflagsource_types_test.go
@@ -419,3 +419,33 @@ func Test_FLagSourceConfiguration_Merge_Keepalive(t *testing.T) {
 	require.Equal(t, 45*time.Second, base.KeepAliveMinTime.Duration)
 	require.NotNil(t, base.KeepAlivePermitWithoutStream)
 }
+
+func Test_FLagSourceConfiguration_ToEnvVars_Keepalive(t *testing.T) {
+	// unset: neither keepalive env var is emitted
+	unset := FeatureFlagSourceSpec{EnvVarPrefix: "FLAGD"}
+	for _, e := range unset.ToEnvVars() {
+		require.NotContains(t, e.Name, "KEEP_ALIVE")
+	}
+
+	// set: both env vars emitted with formatted values
+	permit := true
+	set := FeatureFlagSourceSpec{
+		EnvVarPrefix:                 "FLAGD",
+		KeepAliveMinTime:             &metav1.Duration{Duration: 45 * time.Second},
+		KeepAlivePermitWithoutStream: &permit,
+	}
+	got := set.ToEnvVars()
+	require.Contains(t, got, v1.EnvVar{Name: "FLAGD_KEEP_ALIVE_MIN_TIME", Value: "45s"})
+	require.Contains(t, got, v1.EnvVar{Name: "FLAGD_KEEP_ALIVE_PERMIT_WITHOUT_STREAM", Value: "true"})
+
+	// mixed: only the set field is emitted
+	mixed := FeatureFlagSourceSpec{
+		EnvVarPrefix:     "FLAGD",
+		KeepAliveMinTime: &metav1.Duration{Duration: 1*time.Minute + 30*time.Second},
+	}
+	gotMixed := mixed.ToEnvVars()
+	require.Contains(t, gotMixed, v1.EnvVar{Name: "FLAGD_KEEP_ALIVE_MIN_TIME", Value: "1m30s"})
+	for _, e := range gotMixed {
+		require.NotEqual(t, "FLAGD_KEEP_ALIVE_PERMIT_WITHOUT_STREAM", e.Name)
+	}
+}

--- a/api/core/v1beta1/zz_generated.deepcopy.go
+++ b/api/core/v1beta1/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	apisv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -200,6 +201,16 @@ func (in *FeatureFlagSourceSpec) DeepCopyInto(out *FeatureFlagSourceSpec) {
 		in, out := &in.CORS, &out.CORS
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.KeepAliveMinTime != nil {
+		in, out := &in.KeepAliveMinTime, &out.KeepAliveMinTime
+		*out = new(metav1.Duration)
+		**out = **in
+	}
+	if in.KeepAlivePermitWithoutStream != nil {
+		in, out := &in.KeepAlivePermitWithoutStream, &out.KeepAlivePermitWithoutStream
+		*out = new(bool)
+		**out = **in
 	}
 }
 

--- a/config/crd/bases/core.openfeature.dev_featureflagsources.yaml
+++ b/config/crd/bases/core.openfeature.dev_featureflagsources.yaml
@@ -196,6 +196,16 @@ spec:
                 description: HeaderToContextMappings map HTTP header names to evaluation
                   context keys
                 type: object
+              keepAliveMinTime:
+                description: |-
+                  KeepAliveMinTime sets the minimum interval the flagd sync server permits
+                  between client keepalive pings. When unset, flagd's own default applies.
+                type: string
+              keepAlivePermitWithoutStream:
+                description: |-
+                  KeepAlivePermitWithoutStream permits client keepalive pings even when there
+                  is no active stream. When unset, flagd's own default applies.
+                type: boolean
               logFormat:
                 default: json
                 description: LogFormat allows for the sidecar log format to be overridden,

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -340,6 +340,22 @@ are added at the lowest index, all values will have the EnvVarPrefix applied, de
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>keepAliveMinTime</b></td>
+        <td>string</td>
+        <td>
+          KeepAliveMinTime sets the minimum interval the flagd sync server permits
+between client keepalive pings. When unset, flagd's own default applies.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>keepAlivePermitWithoutStream</b></td>
+        <td>boolean</td>
+        <td>
+          KeepAlivePermitWithoutStream permits client keepalive pings even when there
+is no active stream. When unset, flagd's own default applies.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>logFormat</b></td>
         <td>string</td>
         <td>

--- a/docs/feature_flag_source.md
+++ b/docs/feature_flag_source.md
@@ -148,6 +148,8 @@ Table given below is non-exhaustive list of overriding options. (see [full list]
 | probesEnabled    | Enable/Disable health probes  | true                                           |
 | otelCollectorUri | Otel exporter uri             |                                                |
 | resources        | flagD resources               | operator sidecar-cpu-* and sidecar-ram-* flags |
+| keepAliveMinTime | Minimum interval the flagd sync server permits between client keepalive pings. Optional; when unset, flagd's default applies. |  |
+| keepAlivePermitWithoutStream | Permit client keepalive pings when there is no active stream. Optional; when unset, flagd's default applies. |  |
 
 ## Merging of configurations
 


### PR DESCRIPTION
## What

Adds two opt-in fields to `FeatureFlagSource` that surface flagd's new sync-server gRPC keepalive-enforcement settings, so keepalive tolerance for operator-managed flagd (injected sidecar and standalone `Flagd`) can be tuned from the CRD instead of per-container env/args.

Closes #851.

| Field | Env var emitted | Type | flagd flag |
|---|---|---|---|
| `keepAliveMinTime` | `FLAGD_KEEP_ALIVE_MIN_TIME` | duration | `--keep-alive-min-time` |
| `keepAlivePermitWithoutStream` | `FLAGD_KEEP_ALIVE_PERMIT_WITHOUT_STREAM` | bool | `--keep-alive-permit-without-stream` |

The corresponding flagd flags are **proposed** in open-feature/flagd#1999 (issue #1998). That change and this one are best considered together, but can land in either order — see below.

## Design notes

- **Opt-in, no default.** Both fields are optional pointers with no `+kubebuilder:default`. The env var is emitted only when the field is set; unset means flagd uses its own default, so there is no behaviour change for existing `FeatureFlagSource`s.
- **Env vars, not CLI args.** Surfaced through `FeatureFlagSourceSpec.ToEnvVars()` rather than container args. A flagd that predates these flags silently ignores unknown `FLAGD_*` env vars (whereas an unknown CLI flag would hard-error). So these fields are **inert against the current flagd** and this change has no issues if merged before the flagd change — it is safe to land in either order.
- **No flagd image bump here.** The default flagd tag is unchanged; the fields become functional once the operator's flagd image is bumped to a release with the flags. That bump is intentionally a separate change.
- Both the injected sidecar and the standalone `Flagd` (which references a `FeatureFlagSource`) pick this up through the shared injection path.

## Test plan

- `make unit-test` — new tests for `Merge()` (override/nil) and `ToEnvVars()` (set / unset / mixed / explicit `false`).
- Regenerated CRDs, deepcopy, and CRD docs (`make generate manifests generate-crdocs`); reference doc updated.
- Verified that stock flagd (the currently-pinned image) starts cleanly with `FLAGD_KEEP_ALIVE_MIN_TIME` / `FLAGD_KEEP_ALIVE_PERMIT_WITHOUT_STREAM` set — the unknown env vars are ignored, no crash, output identical to baseline.
